### PR TITLE
fix: enable -Werror and fix all warnings

### DIFF
--- a/cardano-balance-tx.cabal
+++ b/cardano-balance-tx.cabal
@@ -39,13 +39,19 @@ common language
     OverloadedStrings
 
 common opts-lib
-  ghc-options: -Wall -Wcompat -fwarn-redundant-constraints
+  ghc-options:
+    -Wall -Werror -Wcompat -Wunused-imports -Wunused-packages
+    -Wmissing-export-lists -Wname-shadowing
+    -Wdeferred-out-of-scope-variables -Wpartial-type-signatures
+    -Wredundant-constraints
 
   if flag(release)
-    ghc-options: -O2 -Werror
+    ghc-options: -O2
 
 common opts-exe
-  ghc-options: -threaded -rtsopts -Wall
+  ghc-options:
+    -threaded -rtsopts -Wall -Werror -Wunused-imports
+    -Wunused-packages -Wname-shadowing
 
   if flag(release)
     ghc-options: -O2 -Werror
@@ -129,7 +135,6 @@ test-suite unit
     , cardano-balance-tx
     , cardano-binary
     , cardano-coin-selection
-    , cardano-crypto
     , cardano-crypto-class
     , cardano-crypto-test
     , cardano-crypto-wrapper
@@ -145,7 +150,6 @@ test-suite unit
     , cardano-ledger-conway:testlib
     , cardano-ledger-core
     , cardano-ledger-core:testlib
-    , cardano-ledger-mary
     , cardano-ledger-mary:testlib
     , cardano-ledger-shelley
     , cardano-slotting

--- a/lib/Cardano/Balance/Tx/Primitive/Convert.hs
+++ b/lib/Cardano/Balance/Tx/Primitive/Convert.hs
@@ -70,8 +70,7 @@ import Cardano.CoinSelection.Types.TokenQuantity
     ( TokenQuantity (..)
     )
 import Cardano.Crypto.Hash
-    ( Hash (UnsafeHash)
-    , hashFromBytes
+    ( hashFromBytes
     )
 import Cardano.Ledger.Allegra.Scripts
     ( AllegraEraScript

--- a/lib/Cardano/Balance/Tx/SizeEstimation.hs
+++ b/lib/Cardano/Balance/Tx/SizeEstimation.hs
@@ -73,8 +73,6 @@ import qualified Cardano.Address.Script as CA
 import qualified Cardano.Balance.Tx.Primitive as W
 import qualified Cardano.Balance.Tx.Primitive as W.Coin
 import qualified Cardano.Balance.Tx.Primitive as W.TokenBundle
-import qualified Cardano.CoinSelection.Types.TokenBundle as CS.TokenBundle
-import qualified Cardano.CoinSelection.Types.TokenMap as CS.TokenMap
 import qualified Codec.CBOR.Encoding as CBOR
 import qualified Codec.CBOR.Write as CBOR
 import qualified Data.ByteString as BS

--- a/test/spec/Cardano/Balance/Tx/Balance/SurplusSpec.hs
+++ b/test/spec/Cardano/Balance/Tx/Balance/SurplusSpec.hs
@@ -72,15 +72,14 @@ import Prelude
 import qualified Cardano.Balance.Tx.Primitive as W
 import qualified Cardano.Balance.Tx.Primitive as W.Coin
 import qualified Cardano.Balance.Tx.Primitive as W.TxOut
-import qualified Cardano.Balance.Tx.Primitive.Convert as Convert
 import qualified Cardano.Balance.Tx.Primitive.Gen as W
 import qualified Codec.CBOR.Encoding as CBOR
 import qualified Codec.CBOR.Write as CBOR
 import qualified Data.ByteString as BS
 import qualified Data.Foldable as F
 
--- | Polymorphic power, avoids type ambiguity with Prelude '^'.
-power :: (Num a, Integral b) => a -> b -> a
+-- | Power with fixed exponent type to avoid type-defaults warning.
+power :: (Num a) => a -> Int -> a
 power = (^)
 
 spec :: Spec

--- a/test/spec/Cardano/Balance/Tx/BalanceSpec.hs
+++ b/test/spec/Cardano/Balance/Tx/BalanceSpec.hs
@@ -20,6 +20,7 @@
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE ViewPatterns #-}
+{-# OPTIONS_GHC -Wno-deprecations #-}
 {- HLINT ignore "Use null" -}
 {- HLINT ignore "Use camelCase" -}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
@@ -210,9 +211,6 @@ import Control.Monad.Trans.State.Strict
     ( evalState
     , state
     )
-import Data.Bifunctor
-    ( first
-    )
 import Data.ByteArray.Encoding
     ( Base (Base16)
     , convertFromBase
@@ -351,7 +349,6 @@ import Test.QuickCheck
     , Args (..)
     , NonNegative (..)
     , Property
-    , arbitraryBoundedEnum
     , arbitrarySizedNatural
     , checkCoverage
     , choose
@@ -367,7 +364,6 @@ import Test.QuickCheck
     , property
     , quickCheckWith
     , scale
-    , shrinkBoundedEnum
     , shrinkList
     , shrinkMapBy
     , stdArgs
@@ -438,7 +434,6 @@ import qualified Data.Set.NonEmpty as NESet
 import qualified Data.Text as T
 import qualified Data.Text.IO as T
 import qualified Ouroboros.Consensus.HardFork.History as HF
-import qualified Test.Hspec.Extra as Hspec
 
 --------------------------------------------------------------------------------
 -- Specifications

--- a/test/spec/Test/QuickCheck/Extra.hs
+++ b/test/spec/Test/QuickCheck/Extra.hs
@@ -167,7 +167,7 @@ genericRoundRobinShrink fs x =
     SOP.to <$> groundRobinShrinkSOP fs (SOP.from x)
 
 -- | A shrinker for a single field.
-newtype Shrinker a = Shrinker {runShrinker :: a -> [a]}
+newtype Shrinker a = Shrinker (a -> [a])
 
 -- | Function application (like '$') with lower fixity than '<:>'.
 (<@>) :: (a -> b) -> a -> b


### PR DESCRIPTION
## Summary

- Add strict warning flags: -Wall, -Werror, -Wunused-imports, -Wunused-packages, -Wmissing-export-lists, -Wname-shadowing, -Wredundant-constraints
- Remove unused imports and test dependencies
- Fix type-defaults and unused record field warnings
- Suppress Byron deprecation warnings in BalanceSpec