### PR TITLE
docs: replace ASCII diagrams with mermaid flowcharts

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -13,6 +13,12 @@ surplus distribution, token bundle size validation, Plutus redeemer
 assignment, and transaction size estimation across Babbage and Conway
 eras.
 
+```mermaid
+flowchart LR
+    A["Partial Tx\n+ UTxO\n+ Protocol Params"] --> B["balanceTx"]
+    B --> C["Balanced Tx\n(ready to sign)"]
+```
+
 ## Getting started
 
 See the [Getting Started](getting-started.md) guide for build

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,6 +10,12 @@ theme:
   features:
     - navigation.sections
     - content.code.copy
+markdown_extensions:
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
 nav:
   - Home: index.md
   - Getting Started: getting-started.md


### PR DESCRIPTION
## Summary

- Enable `pymdownx.superfences` mermaid support in `mkdocs.yml`
- Replace ASCII pipeline diagram with mermaid flowchart in architecture page
- Add iteration loop diagram, module dependency graph, and landing page data flow diagram

## Test plan

- [x] Run `nix develop github:paolino/dev-assets?dir=mkdocs -c mkdocs serve` and verify all 4 diagrams render as SVGs
- [x] Check dark theme compatibility (slate scheme)