### PR TITLE
fix: relax cardano-addresses lower bound to 4.0.0

### DIFF
--- a/cardano-balance-tx.cabal
+++ b/cardano-balance-tx.cabal
@@ -65,7 +65,7 @@ library
   build-depends:
     , base                         >=4.14      && <5
     , bytestring                   >=0.10.6    && <0.13
-    , cardano-addresses            >=4.0.2     && <4.1
+    , cardano-addresses            >=4.0.0     && <4.1
     , cardano-api                  >=10.23.0.0 && <10.24
     , cardano-coin-selection
     , cardano-crypto-class         ^>=2.2.3


### PR DESCRIPTION
## Summary
- Relax `cardano-addresses` lower bound from `>= 4.0.2` to `>= 4.0.0`
- The wallet's `node-10.6.2` branch pins `cardano-addresses-4.0.0` via CHaP index-state

## Test plan
- [ ] Verify dependency resolution succeeds in cardano-wallet node-10.6.2 branch