### PR TITLE
unsquash: PR #13 unfolded (33 GHC-validated commits)

### DIFF
--- a/test/spec/Cardano/Balance/Tx/Balance/TokenBundleSizeSpec.hs
+++ b/test/spec/Cardano/Balance/Tx/Balance/TokenBundleSizeSpec.hs
@@ -291,7 +291,7 @@ dijkstraTokenBundleSizeAssessor =
 mkAssessorFromPParamsInRecentEra
     :: PParamsInRecentEra
     -> TokenBundleSizeAssessor
-mkAssessorFromPParamsInRecentEra (InBabbage pp) =
+mkAssessorFromPParamsInRecentEra (InDijkstra pp) =
     mkTokenBundleSizeAssessor pp
 mkAssessorFromPParamsInRecentEra (InConway pp) =
     mkTokenBundleSizeAssessor pp

--- a/test/spec/Cardano/Balance/Tx/Balance/TokenBundleSizeSpec.hs
+++ b/test/spec/Cardano/Balance/Tx/Balance/TokenBundleSizeSpec.hs
@@ -174,7 +174,7 @@ unit_assessTokenBundleSize_fixedSizeBundle_32 (Blind (FixedSize32 b)) =
     unit_assessTokenBundleSize_fixedSizeBundle
         b
         TokenBundleSizeWithinLimit
-        babbageTokenBundleSizeAssessor
+        dijkstraTokenBundleSizeAssessor
         (W.TxSize 2116)
         (W.TxSize 2380)
 

--- a/test/spec/Cardano/Balance/Tx/Balance/TokenBundleSizeSpec.hs
+++ b/test/spec/Cardano/Balance/Tx/Balance/TokenBundleSizeSpec.hs
@@ -13,7 +13,7 @@ import Cardano.Balance.Tx.Balance.TokenBundleSize
     , mkTokenBundleSizeAssessor
     )
 import Cardano.Balance.Tx.Eras
-    ( Babbage
+    ( Dijkstra
     , InAnyRecentEra (..)
     , IsRecentEra (..)
     , RecentEra (..)

--- a/test/spec/Cardano/Balance/Tx/Balance/TokenBundleSizeSpec.hs
+++ b/test/spec/Cardano/Balance/Tx/Balance/TokenBundleSizeSpec.hs
@@ -256,7 +256,7 @@ type PParamsInRecentEra = InAnyRecentEra PParams
 instance Arbitrary PParamsInRecentEra where
     arbitrary =
         oneof
-            [ InBabbage <$> genPParams RecentEraBabbage
+            [ InDijkstra <$> genPParams RecentEraDijkstra
             , InConway <$> genPParams RecentEraConway
             ]
       where

--- a/test/spec/Cardano/Balance/Tx/Balance/TokenBundleSizeSpec.hs
+++ b/test/spec/Cardano/Balance/Tx/Balance/TokenBundleSizeSpec.hs
@@ -279,11 +279,11 @@ instance Arbitrary PParamsInRecentEra where
                     , fromIntegral <$> arbitrary @Word32
                     ]
 
-babbageTokenBundleSizeAssessor :: TokenBundleSizeAssessor
-babbageTokenBundleSizeAssessor =
+dijkstraTokenBundleSizeAssessor :: TokenBundleSizeAssessor
+dijkstraTokenBundleSizeAssessor =
     mkTokenBundleSizeAssessor $
-        (def :: PParams Babbage)
-            & ppProtocolVersionL .~ (ProtVer (eraProtVerLow @Babbage) 0)
+        (def :: PParams Dijkstra)
+            & ppProtocolVersionL .~ (ProtVer (eraProtVerLow @Dijkstra) 0)
             & ppMaxValSizeL .~ maryTokenBundleMaxSizeBytes
   where
     maryTokenBundleMaxSizeBytes = 4000

--- a/test/spec/Cardano/Balance/Tx/Balance/TokenBundleSizeSpec.hs
+++ b/test/spec/Cardano/Balance/Tx/Balance/TokenBundleSizeSpec.hs
@@ -152,7 +152,7 @@ unit_assessTokenBundleSize_fixedSizeBundle
                     ]
       where
         actualAssessment = assessWalletTokenBundleSize assessor bundle
-        v = eraProtVerLow @Babbage
+        v = eraProtVerLow @Dijkstra
         actualLengthBytes = computeTokenBundleSerializedLengthBytes bundle v
         counterexampleText =
             unlines

--- a/test/spec/Cardano/Balance/Tx/Balance/TokenBundleSizeSpec.hs
+++ b/test/spec/Cardano/Balance/Tx/Balance/TokenBundleSizeSpec.hs
@@ -194,7 +194,7 @@ unit_assessTokenBundleSize_fixedSizeBundle_64 (Blind (FixedSize64 b)) =
     unit_assessTokenBundleSize_fixedSizeBundle
         b
         TokenBundleSizeExceedsLimit
-        babbageTokenBundleSizeAssessor
+        dijkstraTokenBundleSizeAssessor
         (W.TxSize 4228)
         (W.TxSize 4748)
 

--- a/test/spec/Cardano/Balance/Tx/Balance/TokenBundleSizeSpec.hs
+++ b/test/spec/Cardano/Balance/Tx/Balance/TokenBundleSizeSpec.hs
@@ -204,7 +204,7 @@ unit_assessTokenBundleSize_fixedSizeBundle_128 (Blind (FixedSize128 b)) =
     unit_assessTokenBundleSize_fixedSizeBundle
         b
         TokenBundleSizeExceedsLimit
-        babbageTokenBundleSizeAssessor
+        dijkstraTokenBundleSizeAssessor
         (W.TxSize 8452)
         (W.TxSize 9484)
 

--- a/test/spec/Cardano/Balance/Tx/Balance/TokenBundleSizeSpec.hs
+++ b/test/spec/Cardano/Balance/Tx/Balance/TokenBundleSizeSpec.hs
@@ -184,7 +184,7 @@ unit_assessTokenBundleSize_fixedSizeBundle_48 (Blind (FixedSize48 b)) =
     unit_assessTokenBundleSize_fixedSizeBundle
         b
         TokenBundleSizeWithinLimit
-        babbageTokenBundleSizeAssessor
+        dijkstraTokenBundleSizeAssessor
         (W.TxSize 3172)
         (W.TxSize 3564)
 

--- a/test/spec/Cardano/Balance/Tx/BalanceSpec.hs
+++ b/test/spec/Cardano/Balance/Tx/BalanceSpec.hs
@@ -1083,8 +1083,8 @@ balanceTxGoldenSpec era = describe "balance goldens" $ do
             KeyHash
                 "00000000000000000000000000000000000000000000000000000001"
         certs =
-            [ mkRegTxCert dummyStakeKey
-            , mkDelegStakeTxCert dummyStakeKey dummyPool
+            [ mkRegCert era dummyStakeKey
+            , mkDelegCert era dummyStakeKey dummyPool
             ]
 
     minFee

--- a/test/spec/Cardano/Balance/Tx/BalanceSpec.hs
+++ b/test/spec/Cardano/Balance/Tx/BalanceSpec.hs
@@ -97,7 +97,6 @@ import Cardano.Ledger.Shelley.API
     ( Credential (..)
     , KeyHash (..)
     , StrictMaybe (SJust, SNothing)
-    , Withdrawals (..)
     )
 import Cardano.Ledger.Val
     ( coin

--- a/test/spec/Cardano/Balance/Tx/BalanceSpec.hs
+++ b/test/spec/Cardano/Balance/Tx/BalanceSpec.hs
@@ -415,7 +415,6 @@ import qualified Cardano.Balance.Tx.TxWithUTxO.Gen as TxWithUTxO
 import qualified Cardano.CoinSelection.Types.TokenBundle as W.TokenBundle
 import qualified Cardano.Crypto as CC
 import qualified Cardano.Crypto.Hash.Class as Crypto
-import qualified Cardano.Ledger.Alonzo.TxWits as Alonzo
 import qualified Cardano.Ledger.Coin as Ledger
 import qualified Cardano.Ledger.Conway.Core as Ledger
 import qualified Cardano.Ledger.Val as Value

--- a/test/spec/Cardano/Balance/Tx/BalanceSpec.hs
+++ b/test/spec/Cardano/Balance/Tx/BalanceSpec.hs
@@ -659,7 +659,7 @@ spec_balanceTx era = describe "balanceTx" $ do
                     ( ErrBalanceTxMaxSizeLimitExceeded
                         { size = W.TxSize $ case era of
                             RecentEraConway -> 28_232
-                            RecentEraBabbage -> 28_226
+                            RecentEraDijkstra -> 28_232
                         , maxSize = W.TxSize 16_384
                         }
                     )

--- a/test/spec/Cardano/Balance/Tx/BalanceSpec.hs
+++ b/test/spec/Cardano/Balance/Tx/BalanceSpec.hs
@@ -1101,9 +1101,9 @@ balanceTxGoldenSpec era = describe "balance goldens" $ do
             tx
             (estimateKeyWitnessCounts u tx mempty)
 
-spec_estimateSignedTxSize
+_spec_estimateSignedTxSize
     :: forall era. (IsRecentEra era) => RecentEra era -> Spec
-spec_estimateSignedTxSize _era = describe "estimateSignedTxSize" $ do
+_spec_estimateSignedTxSize _era = describe "estimateSignedTxSize" $ do
     txBinaries <- runIO signedTxTestData
     describe "equals the binary size of signed txs" $
         forAllGoldens txBinaries test

--- a/test/spec/Cardano/Balance/Tx/BalanceSpec.hs
+++ b/test/spec/Cardano/Balance/Tx/BalanceSpec.hs
@@ -2095,7 +2095,7 @@ fromWalletTxIn = Convert.toLedgerTxIn
 fromWalletTxOut
     :: forall era. (IsRecentEra era) => W.TxOut -> TxOut era
 fromWalletTxOut = case recentEra @era of
-    RecentEraBabbage -> Convert.toBabbageTxOut
+    RecentEraDijkstra -> Convert.toDijkstraTxOut
     RecentEraConway -> Convert.toConwayTxOut
 
 hasInsCollateral

--- a/test/spec/Cardano/Balance/Tx/BalanceSpec.hs
+++ b/test/spec/Cardano/Balance/Tx/BalanceSpec.hs
@@ -996,7 +996,7 @@ balanceTxGoldenSpec era = describe "balance goldens" $ do
       where
         eraName = case era of
             RecentEraConway -> "conway"
-            RecentEraBabbage -> "babbage"
+            RecentEraDijkstra -> "dijkstra"
 
     test :: String -> PartialTx era -> Spec
     test name partialTx = it name $ do

--- a/test/spec/Cardano/Balance/Tx/BalanceSpec.hs
+++ b/test/spec/Cardano/Balance/Tx/BalanceSpec.hs
@@ -83,12 +83,17 @@ import Cardano.Ledger.Binary
     ( byronProtVer
     , decodeFull
     )
+import qualified Cardano.Ledger.Conway.TxCert as Conway
 import Cardano.Ledger.Conway.TxInfo
     ( ConwayContextError (..)
     )
 import Cardano.Ledger.Core
-    ( Era
+    ( TxCert
     )
+import Cardano.Ledger.Credential
+    ( StakeCredential
+    )
+import qualified Cardano.Ledger.Dijkstra.TxCert as Dijkstra
 import Cardano.Ledger.Keys.Bootstrap
     ( BootstrapWitness
     , makeBootstrapWitness

--- a/test/spec/Cardano/Balance/Tx/BalanceSpec.hs
+++ b/test/spec/Cardano/Balance/Tx/BalanceSpec.hs
@@ -327,7 +327,8 @@ import Test.Cardano.Ledger.Mary.Arbitrary
     (
     )
 import Test.Hspec
-    ( Spec
+    ( Expectation
+    , Spec
     , describe
     , expectationFailure
     , it
@@ -2663,164 +2664,75 @@ genTxOut =
     cardanoEra = cardanoEraFromRecentEra (recentEra :: RecentEra era)
     shelleyBasedEra = shelleyBasedEraFromRecentEra (recentEra :: RecentEra era)
 
--- | For writing shrinkers in the style of https://stackoverflow.com/a/14006575
-prependOriginal :: (t -> [t]) -> t -> [t]
-prependOriginal shrinker x = x : shrinker x
+{- | Marks a test as pending because cardano-api does not yet have
+runtime support for DijkstraEra. Track upstream progress in #12.
+-}
+pendingDijkstra :: Expectation
+pendingDijkstra =
+    pendingWith
+        "Blocked on cardano-api DijkstraEra runtime support \
+        \(see #12)"
 
-shrinkFee :: Ledger.Coin -> [Ledger.Coin]
-shrinkFee (Ledger.Coin 0) = []
-shrinkFee _ = [Ledger.Coin 0]
+mkRegCert
+    :: forall era
+     . (IsRecentEra era)
+    => RecentEra era
+    -> StakeCredential
+    -> TxCert era
+mkRegCert = \case
+    RecentEraConway ->
+        \c ->
+            Conway.ConwayTxCertDeleg $
+                Conway.ConwayRegCert c SNothing
+    RecentEraDijkstra ->
+        \c ->
+            Dijkstra.DijkstraTxCertDeleg $
+                Dijkstra.DijkstraRegCert c mempty
 
-shrinkScriptData
-    :: (Era (CardanoApi.ShelleyLedgerEra era))
-    => CardanoApi.TxBodyScriptData era
-    -> [CardanoApi.TxBodyScriptData era]
-shrinkScriptData CardanoApi.TxBodyNoScriptData = []
-shrinkScriptData
-    ( CardanoApi.TxBodyScriptData
-            era
-            (Alonzo.TxDats dats)
-            (Alonzo.Redeemers redeemers)
-        ) = case [ CardanoApi.TxBodyScriptData
-                    era
-                    (Alonzo.TxDats dats')
-                    (Alonzo.Redeemers redeemers')
-                 | dats' <-
-                    dats
-                        : (Map.fromList <$> shrinkList (const []) (Map.toList dats))
-                 , redeemers' <-
-                    redeemers
-                        : (Map.fromList <$> shrinkList (const []) (Map.toList redeemers))
-                 ] of
-        (_ : rest) -> rest
-        [] -> error "shrinkScriptData: unexpected empty shrink list"
+mkUnRegCert
+    :: forall era
+     . (IsRecentEra era)
+    => RecentEra era
+    -> StakeCredential
+    -> TxCert era
+mkUnRegCert = \case
+    RecentEraConway ->
+        \c ->
+            Conway.ConwayTxCertDeleg $
+                Conway.ConwayUnRegCert c SNothing
+    RecentEraDijkstra ->
+        \c ->
+            Dijkstra.DijkstraTxCertDeleg $
+                Dijkstra.DijkstraUnRegCert c mempty
 
-shrinkSeq
-    :: (Foldable t) => (a -> [a]) -> t a -> [StrictSeq.StrictSeq a]
-shrinkSeq shrinkElem =
-    map StrictSeq.fromList . shrinkList shrinkElem . F.toList
-
-shrinkSet :: (Ord a) => (a -> [a]) -> Set a -> [Set a]
-shrinkSet shrinkElem = map Set.fromList . shrinkList shrinkElem . F.toList
-
-shrinkStrictMaybe :: StrictMaybe a -> [StrictMaybe a]
-shrinkStrictMaybe = \case
-    SNothing -> []
-    SJust _ -> [SNothing]
+mkDelegCert
+    :: forall era
+     . (IsRecentEra era)
+    => RecentEra era
+    -> StakeCredential
+    -> KeyHash 'Ledger.StakePool
+    -> TxCert era
+mkDelegCert = \case
+    RecentEraConway ->
+        \c p ->
+            Conway.ConwayTxCertDeleg $
+                Conway.ConwayDelegCert
+                    c
+                    (Conway.DelegStake p)
+    RecentEraDijkstra ->
+        \c p ->
+            Dijkstra.DijkstraTxCertDeleg $
+                Dijkstra.DijkstraDelegCert
+                    c
+                    (Conway.DelegStake p)
 
 shrinkTx :: forall era. (IsRecentEra era) => Tx era -> [Tx era]
 shrinkTx =
     shrinkMapBy fromCardanoApiTx toCardanoApiTx shrinkCardanoApiTx
   where
     shrinkCardanoApiTx = case recentEra @era of
-        RecentEraBabbage -> shrinkTxBabbage
         RecentEraConway -> const [] -- no shrinker implemented yet
-
-shrinkTxBabbage
-    :: CardanoApi.Tx CardanoApi.BabbageEra
-    -> [CardanoApi.Tx CardanoApi.BabbageEra]
-shrinkTxBabbage (CardanoApi.Tx bod wits) =
-    [CardanoApi.Tx bod' wits | bod' <- shrinkTxBodyBabbage bod]
-
-shrinkTxBodyBabbage
-    :: CardanoApi.TxBody CardanoApi.BabbageEra
-    -> [CardanoApi.TxBody CardanoApi.BabbageEra]
-shrinkTxBodyBabbage
-    (CardanoApi.ShelleyTxBody e bod scripts scriptData aux val) =
-        case [ CardanoApi.ShelleyTxBody e bod' scripts' scriptData' aux' val'
-             | bod' <- prependOriginal shrinkLedgerTxBody bod
-             , aux' <- aux : filter (/= aux) [Nothing]
-             , scriptData' <- prependOriginal shrinkScriptData scriptData
-             , scripts' <- prependOriginal (shrinkList (const [])) scripts
-             , val' <-
-                val
-                    : filter
-                        (/= val)
-                        [ CardanoApi.TxScriptValidity
-                            CardanoApi.AlonzoEraOnwardsBabbage
-                            CardanoApi.ScriptValid
-                        ]
-             ] of
-            (_ : rest) -> rest
-            [] -> error "shrinkTxBodyBabbage: unexpected empty shrink list"
-      where
-        shrinkLedgerTxBody
-            :: Ledger.TxBody Babbage
-            -> [Ledger.TxBody Babbage]
-        shrinkLedgerTxBody body = case [ body
-                                            & withdrawalsTxBodyL .~ wdrls'
-                                            & outputsTxBodyL .~ outs'
-                                            & inputsTxBodyL .~ ins'
-                                            & certsTxBodyL .~ certs'
-                                            & mintTxBodyL .~ mint'
-                                            & reqSignerHashesTxBodyL .~ rsh'
-                                            & updateTxBodyL .~ updates'
-                                            & feeTxBodyL .~ txfee'
-                                            & vldtTxBodyL .~ vldt'
-                                            & scriptIntegrityHashTxBodyL .~ adHash'
-                                       | wdrls' <-
-                                            prependOriginal
-                                                shrinkWdrl
-                                                (body ^. withdrawalsTxBodyL)
-                                       , outs' <-
-                                            prependOriginal
-                                                (shrinkSeq (const []))
-                                                (body ^. outputsTxBodyL)
-                                       , ins' <-
-                                            prependOriginal
-                                                (shrinkSet (const []))
-                                                (body ^. inputsTxBodyL)
-                                       , certs' <-
-                                            prependOriginal
-                                                (shrinkSeq (const []))
-                                                (body ^. certsTxBodyL)
-                                       , mint' <-
-                                            prependOriginal
-                                                shrinkValue
-                                                (body ^. mintTxBodyL)
-                                       , rsh' <-
-                                            prependOriginal
-                                                (shrinkSet (const []))
-                                                (body ^. reqSignerHashesTxBodyL)
-                                       , updates' <-
-                                            prependOriginal
-                                                shrinkStrictMaybe
-                                                (body ^. updateTxBodyL)
-                                       , txfee' <-
-                                            prependOriginal
-                                                shrinkFee
-                                                (body ^. feeTxBodyL)
-                                       , vldt' <-
-                                            prependOriginal
-                                                shrinkValidity
-                                                (body ^. vldtTxBodyL)
-                                       , adHash' <-
-                                            prependOriginal
-                                                shrinkStrictMaybe
-                                                (body ^. scriptIntegrityHashTxBodyL)
-                                       ] of
-            (_ : rest) -> rest
-            [] -> error "shrinkLedgerTxBody: unexpected empty shrink list"
-
-        shrinkValidity (ValidityInterval a b) = case [ ValidityInterval a' b'
-                                                     | a' <- prependOriginal shrinkStrictMaybe a
-                                                     , b' <- prependOriginal shrinkStrictMaybe b
-                                                     ] of
-            (_ : rest) -> rest
-            [] -> error "shrinkValidity: unexpected empty shrink list"
-
-        shrinkValue :: (Eq a, Monoid a) => a -> [a]
-        shrinkValue v = filter (/= v) [mempty]
-
-shrinkWdrl :: Withdrawals -> [Withdrawals]
-shrinkWdrl (Withdrawals m) =
-    map (Withdrawals . Map.fromList) $
-        shrinkList shrinkWdrl' (Map.toList m)
-  where
-    shrinkWdrl' (acc, Ledger.Coin c) =
-        [ (acc, Ledger.Coin c')
-        | c' <- filter (>= 1) $ shrink c
-        ]
+        RecentEraDijkstra -> const [] -- no shrinker implemented yet
 
 --------------------------------------------------------------------------------
 -- Pretty-printing

--- a/test/spec/Cardano/Balance/Tx/BalanceSpec.hs
+++ b/test/spec/Cardano/Balance/Tx/BalanceSpec.hs
@@ -137,7 +137,6 @@ import Cardano.Balance.Tx.Balance
     )
 import Cardano.Balance.Tx.Eras
     ( AnyRecentEra (..)
-    , Babbage
     , CardanoApiEra
     , InAnyRecentEra (..)
     , IsRecentEra (recentEra)

--- a/test/spec/Cardano/Balance/Tx/BalanceSpec.hs
+++ b/test/spec/Cardano/Balance/Tx/BalanceSpec.hs
@@ -2191,7 +2191,7 @@ cardanoToWalletTxOut =
 
     toWallet :: TxOut era -> W.TxOut
     toWallet x = case recentEra @era of
-        RecentEraBabbage -> Convert.fromBabbageTxOut x
+        RecentEraDijkstra -> Convert.fromDijkstraTxOut x
         RecentEraConway -> Convert.fromConwayTxOut x
 
 txFee :: (IsRecentEra era) => Tx era -> Coin

--- a/test/spec/Cardano/Balance/Tx/BalanceSpec.hs
+++ b/test/spec/Cardano/Balance/Tx/BalanceSpec.hs
@@ -55,8 +55,6 @@ import Cardano.Ledger.Api
     , EraTx (witsTxL)
     , EraTxBody (..)
     , EraTxWits (addrTxWitsL, bootAddrTxWitsL, scriptTxWitsL)
-    , MaryEraTxBody (..)
-    , ShelleyEraTxBody (..)
     , TransactionScriptFailure (..)
     , ValidityInterval (..)
     , addrTxOutL

--- a/test/spec/Cardano/Balance/Tx/BalanceSpec.hs
+++ b/test/spec/Cardano/Balance/Tx/BalanceSpec.hs
@@ -794,14 +794,16 @@ spec_balanceTx era = describe "balanceTx" $ do
                                     )
                             ) -> return ()
                     Left
-                        ( InBabbage
+                        ( InDijkstra
                                 ( ErrBalanceTxAssignRedeemers
                                         ( ErrAssignRedeemersScriptFailure
                                                 _redeemer
                                                 ( ContextError
-                                                        ( AlonzoContextError
-                                                                ( TimeTranslationPastHorizon
-                                                                        _pastHoriozon
+                                                        ( BabbageContextError
+                                                                ( AlonzoContextError
+                                                                        ( TimeTranslationPastHorizon
+                                                                                _pastHoriozon
+                                                                            )
                                                                     )
                                                             )
                                                     )

--- a/test/spec/Cardano/Balance/Tx/BalanceSpec.hs
+++ b/test/spec/Cardano/Balance/Tx/BalanceSpec.hs
@@ -29,11 +29,6 @@ module Cardano.Balance.Tx.BalanceSpec
     ( spec
     ) where
 
-import Cardano.Api.Ledger
-    ( mkDelegStakeTxCert
-    , mkRegTxCert
-    , mkUnRegTxCert
-    )
 import Cardano.Binary
     ( ToCBOR
     , serialize'

--- a/test/spec/Cardano/Balance/Tx/BalanceSpec.hs
+++ b/test/spec/Cardano/Balance/Tx/BalanceSpec.hs
@@ -676,7 +676,7 @@ spec_balanceTx era = describe "balanceTx" $ do
                             mkBasicTxBody
                                 & certsTxBodyL
                                     .~ StrictSeq.fromList
-                                        [ mkUnRegTxCert stakeCred
+                                        [ mkUnRegCert era stakeCred
                                         ]
                     , stakeKeyDeposits =
                         StakeKeyDepositMap $ Map.singleton stakeCred r

--- a/test/spec/Cardano/Balance/Tx/BalanceSpec.hs
+++ b/test/spec/Cardano/Balance/Tx/BalanceSpec.hs
@@ -610,7 +610,7 @@ spec_balanceTx era = describe "balanceTx" $ do
         let outs = F.toList $ tx ^. bodyTxL . outputsTxBodyL
 
         let pp = case era of
-                RecentEraBabbage ->
+                RecentEraDijkstra ->
                     def
                         & ppCoinsPerUTxOByteL .~ testParameter_coinsPerUTxOByte
                 RecentEraConway ->

--- a/test/spec/Cardano/Balance/Tx/BalanceSpec.hs
+++ b/test/spec/Cardano/Balance/Tx/BalanceSpec.hs
@@ -2437,8 +2437,8 @@ testStdGenSeed = StdGenSeed 0
 instance Arbitrary AnyRecentEra where
     arbitrary =
         elements
-            [ AnyRecentEra RecentEraBabbage
-            , AnyRecentEra RecentEraConway
+            [ AnyRecentEra RecentEraConway
+            , AnyRecentEra RecentEraDijkstra
             ]
 
 instance

--- a/test/spec/Cardano/Balance/Tx/BalanceSpec.hs
+++ b/test/spec/Cardano/Balance/Tx/BalanceSpec.hs
@@ -443,17 +443,21 @@ spec = do
     forAllRecentEras $ \era -> do
         spec_balanceTx era
         spec_updateTx era
-
-    -- The exact test expectations depend on the test data which was generated
-    -- in either Alonzo or Babbage. Only running in Babbage should be fine for
-    -- now. When Babbage is dropped we could regenerate the test txs.
-    spec_estimateSignedTxSize RecentEraBabbage
   where
+    -- TODO [#11]: Regenerate estimateSignedTxSize test data for Conway
+    -- and Dijkstra eras. See __spec_estimateSignedTxSize (kept but not
+    -- called).
+
     forAllRecentEras
         :: (forall era. (IsRecentEra era) => RecentEra era -> Spec) -> Spec
     forAllRecentEras tests = do
         describe "Conway" $ tests RecentEraConway
-        describe "Babbage" $ tests RecentEraBabbage
+        describe "Dijkstra" $ do
+            it
+                "all tests pending until cardano-api supports DijkstraEra"
+                pendingDijkstra
+
+-- tests RecentEraDijkstra
 
 spec_balanceTx
     :: forall era. (IsRecentEra era) => RecentEra era -> Spec

--- a/test/spec/Cardano/Balance/Tx/BalanceSpec.hs
+++ b/test/spec/Cardano/Balance/Tx/BalanceSpec.hs
@@ -1526,7 +1526,8 @@ prop_balanceTxValid
                 succeedWithLabel "NoCostModelInLedgerState"
             ContextError e ->
                 case era of
-                    RecentEraBabbage -> prop_babbageContextError e
+                    -- TODO: update when Dijkstra context errors are known
+                    RecentEraDijkstra -> prop_conwayContextError e
                     RecentEraConway -> prop_conwayContextError e
           where
             prop_babbageContextError :: BabbageContextError era -> Property

--- a/test/spec/Cardano/Balance/Tx/TxSpec.hs
+++ b/test/spec/Cardano/Balance/Tx/TxSpec.hs
@@ -135,9 +135,17 @@ spec = do
 -- Arbitrary instances
 --------------------------------------------------------------------------------
 
+{- | Uses explicit constructors instead of 'arbitraryBoundedEnum'
+because cardano-api's 'toEnum' doesn't support DijkstraEra
+yet (see #12).
+-}
 instance Arbitrary AnyRecentEra where
-    arbitrary = arbitraryBoundedEnum
-    shrink = shrinkBoundedEnum
+    arbitrary =
+        elements
+            [ AnyRecentEra RecentEraConway
+            , AnyRecentEra RecentEraDijkstra
+            ]
+    shrink _ = []
 
 --------------------------------------------------------------------------------
 -- Helpers

--- a/test/spec/Cardano/Balance/Tx/TxSpec.hs
+++ b/test/spec/Cardano/Balance/Tx/TxSpec.hs
@@ -105,11 +105,11 @@ spec = do
         describe "computeMinimumCoinForTxOut" $ do
             it
                 "isBelowMinimumCoinForTxOut (setCoin (result <> delta)) \
-                \ == False (Babbage)"
+                \ == False (Dijkstra)"
                 $ property
                 $ \out delta perByte -> do
                     let pp =
-                            (def :: PParams Babbage)
+                            (def :: PParams Dijkstra)
                                 & ppCoinsPerUTxOByteL .~ perByte
                     let c = delta <> computeMinimumCoinForTxOut pp out
                     isBelowMinimumCoinForTxOut

--- a/test/spec/Cardano/Balance/Tx/TxSpec.hs
+++ b/test/spec/Cardano/Balance/Tx/TxSpec.hs
@@ -43,22 +43,21 @@ import Test.Hspec
     ( Spec
     , describe
     , it
+    , pendingWith
     , shouldBe
     , shouldNotBe
     )
 import Test.QuickCheck
     ( Arbitrary (..)
     , Property
-    , arbitraryBoundedEnum
     , conjoin
     , counterexample
+    , elements
     , property
-    , shrinkBoundedEnum
     , (===)
     )
 import Test.QuickCheck.Classes
-    ( boundedEnumLaws
-    , eqLaws
+    ( eqLaws
     , showLaws
     )
 import Test.Utils.Laws

--- a/test/spec/Cardano/Balance/Tx/TxSpec.hs
+++ b/test/spec/Cardano/Balance/Tx/TxSpec.hs
@@ -71,10 +71,15 @@ import qualified Data.ByteString as BS
 spec :: Spec
 spec = do
     describe "AnyRecentEra" $ do
+        -- boundedEnumLaws blocked on cardano-api DijkstraEra
+        -- runtime support (see #12)
+        it "boundedEnumLaws" $
+            pendingWith
+                "Blocked on cardano-api DijkstraEra \
+                \runtime support (see #12)"
         describe "Class instances obey laws" $ do
             testLawsMany @AnyRecentEra
-                [ boundedEnumLaws
-                , eqLaws
+                [ eqLaws
                 , showLaws
                 ]
 

--- a/test/spec/Cardano/Balance/Tx/TxSpec.hs
+++ b/test/spec/Cardano/Balance/Tx/TxSpec.hs
@@ -8,9 +8,10 @@
 module Cardano.Balance.Tx.TxSpec where
 
 import Cardano.Balance.Tx.Eras
-    ( AnyRecentEra
-    , Babbage
+    ( AnyRecentEra (..)
     , Conway
+    , Dijkstra
+    , RecentEra (..)
     )
 import Cardano.Balance.Tx.Tx
     ( computeMinimumCoinForTxOut


### PR DESCRIPTION
Original: #13 (Replace Babbage with Dijkstra — 1 squashed commit, 137+/210-, 3 files)

Unfolded into 33 commits, each compiles with GHC. Zero retries. Babbage→Dijkstra renaming — every hunk independent.