### PR TITLE
Remove unused test deps, fix collateral generators

### DIFF
--- a/cardano-balance-tx.cabal
+++ b/cardano-balance-tx.cabal
@@ -125,7 +125,6 @@ test-suite unit
   hs-source-dirs:     test/spec test/data
   main-is:            run-test-suite.hs
   build-depends:
-    , aeson
     , base
     , bytestring
     , cardano-addresses
@@ -133,7 +132,6 @@ test-suite unit
     , cardano-binary
     , cardano-coin-selection
     , cardano-crypto-class
-    , cardano-crypto-test
     , cardano-crypto-wrapper
     , cardano-ledger-alonzo
     , cardano-ledger-alonzo:testlib
@@ -142,12 +140,10 @@ test-suite unit
     , cardano-ledger-babbage:testlib
     , cardano-ledger-binary
     , cardano-ledger-byron
-    , cardano-ledger-byron-test
     , cardano-ledger-conway
     , cardano-ledger-conway:testlib
     , cardano-ledger-dijkstra
     , cardano-ledger-core
-    , cardano-ledger-core:testlib
     , cardano-ledger-mary:testlib
     , cardano-ledger-shelley
     , cardano-slotting
@@ -161,27 +157,21 @@ test-suite unit
     , generic-lens
     , generics-sop
     , groups
-    , hedgehog-quickcheck
     , hspec
     , hspec-core
     , hspec-golden
     , int-cast
-    , iproute
     , lens
     , memory
     , MonadRandom
     , monoid-subclasses
-    , network
     , nonempty-containers
     , OddWord
-    , ordered-containers
     , ouroboros-consensus
     , ouroboros-network-api
-    , plutus-ledger-api:plutus-ledger-api-testlib
     , pretty-show
     , QuickCheck
     , quickcheck-classes
-    , quickcheck-instances
     , quiet
     , random
     , sop-extras

--- a/test/spec/Cardano/Balance/Tx/BalanceSpec.hs
+++ b/test/spec/Cardano/Balance/Tx/BalanceSpec.hs
@@ -2600,14 +2600,47 @@ instance forall era. (IsRecentEra era) => Arbitrary (Wallet era) where
 The transaction has some random outputs but no inputs (to be
 filled by coin selection) and zero fees (to be computed).
 -}
+
+{- | Generate a transaction suitable for balancing tests.
+Sometimes includes collateral fields to exercise rejection paths.
+-}
 genTxForBalancing :: forall era. (IsRecentEra era) => Gen (Tx era)
 genTxForBalancing = do
     nOuts <- choose (0, 5)
     outs <- vectorOf nOuts genTxOut
-    pure $
-        mkBasicTx $
+    body <-
+        addCollateral $
             mkBasicTxBody
                 & outputsTxBodyL .~ StrictSeq.fromList outs
+    pure $ mkBasicTx body
+  where
+    addCollateral body =
+        frequency
+            [ (7, pure body)
+            ,
+                ( 1
+                , pure $
+                    body
+                        & totalCollateralTxBodyL .~ SJust (Coin 1_000_000)
+                )
+            ,
+                ( 1
+                , do
+                    ret <- genTxOut
+                    pure $
+                        body
+                            & collateralReturnTxBodyL .~ SJust ret
+                )
+            ,
+                ( 1
+                , do
+                    ret <- genTxOut
+                    pure $
+                        body
+                            & totalCollateralTxBodyL .~ SJust (Coin 1_000_000)
+                            & collateralReturnTxBodyL .~ SJust ret
+                )
+            ]
 
 genTxIn :: Gen TxIn
 genTxIn = fromWalletTxIn <$> W.genTxIn


### PR DESCRIPTION
Remove 10 unused test deps. Fix genTxForBalancing to generate collateral fields.