### PR TITLE
chore: bump dependencies to cardano-node 10.7.1

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -14,11 +14,11 @@ repository cardano-haskell-packages
     c00aae8461a256275598500ea0e187588c35a5d5d7454fb57eac18d9edb86a56
     d4a35cd3121aa00d18544bb0ac01c3e1691d618f462c46129271bccf39f7e8ee
 
-index-state: 2026-01-29T00:00:00Z
+index-state: 2026-02-14T00:39:24Z
 
 index-state:
-  , hackage.haskell.org 2026-01-29T00:00:00Z
-  , cardano-haskell-packages 2026-02-09T17:36:58Z
+  , hackage.haskell.org 2026-02-14T00:39:24Z
+  , cardano-haskell-packages 2026-03-23T18:21:55Z
 
 packages:
   .
@@ -49,6 +49,8 @@ allow-newer:
   , cardano-cli:cardano-api
   , si-timers:io-classes
   , hkd:base
+  , quickcheck-state-machine:random
+  , cardano-coin-selection:random
 
 constraints:
     base >= 4.18.2.0 && < 5

--- a/cabal.project
+++ b/cabal.project
@@ -14,11 +14,11 @@ repository cardano-haskell-packages
     c00aae8461a256275598500ea0e187588c35a5d5d7454fb57eac18d9edb86a56
     d4a35cd3121aa00d18544bb0ac01c3e1691d618f462c46129271bccf39f7e8ee
 
-index-state: 2026-02-14T00:39:24Z
+index-state: 2026-03-26T20:21:33Z
 
 index-state:
-  , hackage.haskell.org 2026-02-14T00:39:24Z
-  , cardano-haskell-packages 2026-03-23T18:21:55Z
+  , hackage.haskell.org 2026-03-26T20:21:33Z
+  , cardano-haskell-packages 2026-04-14T21:25:56Z
 
 packages:
   .

--- a/cardano-balance-tx.cabal
+++ b/cardano-balance-tx.cabal
@@ -63,40 +63,41 @@ library
   import:          language, opts-lib
   hs-source-dirs:  lib
   build-depends:
-    , base                         >=4.14      && <5
-    , bytestring                   >=0.10.6    && <0.13
-    , cardano-addresses            >=4.0.2     && <4.1
+    , base                       >=4.14     && <5
+    , bytestring                 >=0.10.6   && <0.13
+    , cardano-addresses          >=4.0.2    && <4.1
     , cardano-coin-selection
-    , cardano-crypto-class         >=2.3.1     && <2.4
-    , cardano-ledger-allegra       >=1.9.0.0   && <1.10
-    , cardano-ledger-alonzo        >=1.15.0.0  && <1.16
-    , cardano-ledger-api           >=1.13.0.0  && <1.14
-    , cardano-ledger-babbage       >=1.13.0.0  && <1.14
+    , cardano-crypto-class       >=2.3.1    && <2.4
+    , cardano-ledger-allegra     >=1.9.0.0  && <1.10
+    , cardano-ledger-alonzo      >=1.15.0.0 && <1.16
+    , cardano-ledger-api         >=1.13.0.0 && <1.14
+    , cardano-ledger-babbage     >=1.13.0.0 && <1.14
     , cardano-ledger-binary
-    , cardano-ledger-conway        >=1.21.0.0  && <1.22
-    , cardano-ledger-dijkstra      >=0.2.0.0   && <0.3
-    , cardano-ledger-core          >=1.19.0.0  && <1.20
-    , cardano-ledger-mary          >=1.10.0.0  && <1.11
-    , cardano-ledger-shelley       >=1.18.0.0  && <1.19
-    , cardano-slotting             >=0.2.1.0   && <0.3
-    , cardano-strict-containers    >=0.1.6.0   && <0.2
-    , cborg                        >=0.2.1     && <0.3
-    , containers                   >=0.5       && <0.8
-    , deepseq                      >=1.4.4     && <1.6
-    , fmt                          >=0.6.3     && <0.7
-    , generic-lens                 >=2.2.2.0   && <2.3
-    , groups                       >=0.5.3     && <0.6
-    , int-cast                     >=0.2.0.0   && <0.3
-    , lens                         >=5.2.3     && <5.4
-    , MonadRandom                  >=0.6       && <0.7
-    , monoid-subclasses            >=1.2.5.1   && <1.3
-    , nonempty-containers          >=0.3.4.5   && <0.4
-    , ouroboros-consensus          >=1.0.0.0   && <1.1
-    , pretty-simple                >=4.1.2.0   && <4.2
-    , QuickCheck                   >=2.14      && <2.16.0
-    , serialise                    >=0.2.6.1   && <0.3
-    , text                         >=1.2       && <2.2
-    , transformers                 >=0.6.1.0   && <0.7
+    , cardano-ledger-conway      >=1.21.0.0 && <1.22
+    , cardano-ledger-core        >=1.19.0.0 && <1.20
+    , cardano-ledger-dijkstra    >=0.2.0.0  && <0.3
+    , cardano-ledger-mary        >=1.10.0.0 && <1.11
+    , cardano-ledger-shelley     >=1.18.0.0 && <1.19
+    , cardano-protocol-tpraos    >=1.5.0.0  && <1.6
+    , cardano-slotting           >=0.2.1.0  && <0.3
+    , cardano-strict-containers  >=0.1.6.0  && <0.2
+    , cborg                      >=0.2.1    && <0.3
+    , containers                 >=0.5      && <0.8
+    , deepseq                    >=1.4.4    && <1.6
+    , fmt                        >=0.6.3    && <0.7
+    , generic-lens               >=2.2.2.0  && <2.3
+    , groups                     >=0.5.3    && <0.6
+    , int-cast                   >=0.2.0.0  && <0.3
+    , lens                       >=5.2.3    && <5.4
+    , MonadRandom                >=0.6      && <0.7
+    , monoid-subclasses          >=1.2.5.1  && <1.3
+    , nonempty-containers        >=0.3.4.5  && <0.4
+    , ouroboros-consensus        >=1.0.0.0  && <1.1
+    , pretty-simple              >=4.1.2.0  && <4.2
+    , QuickCheck                 >=2.14     && <2.16.0
+    , serialise                  >=0.2.6.1  && <0.3
+    , text                       >=1.2      && <2.2
+    , transformers               >=0.6.1.0  && <0.7
 
   exposed-modules:
     Cardano.Balance.Tx.Balance
@@ -133,15 +134,14 @@ test-suite unit
     , cardano-crypto-class
     , cardano-crypto-wrapper
     , cardano-ledger-alonzo
-    , cardano-ledger-alonzo-test
     , cardano-ledger-api
     , cardano-ledger-babbage
     , cardano-ledger-binary
     , cardano-ledger-byron
     , cardano-ledger-conway
-    , cardano-ledger-dijkstra
     , cardano-ledger-core
-    , cardano-ledger-shelley-ma-test
+    , cardano-ledger-dijkstra
+    , cardano-ledger-mary
     , cardano-ledger-shelley
     , cardano-slotting
     , cardano-strict-containers
@@ -165,7 +165,6 @@ test-suite unit
     , nonempty-containers
     , OddWord
     , ouroboros-consensus
-    , ouroboros-network
     , pretty-show
     , QuickCheck
     , quickcheck-classes

--- a/cardano-balance-tx.cabal
+++ b/cardano-balance-tx.cabal
@@ -134,14 +134,17 @@ test-suite unit
     , cardano-crypto-class
     , cardano-crypto-wrapper
     , cardano-ledger-alonzo
+    , cardano-ledger-alonzo:testlib
     , cardano-ledger-api
     , cardano-ledger-babbage
+    , cardano-ledger-babbage:testlib
     , cardano-ledger-binary
     , cardano-ledger-byron
     , cardano-ledger-conway
+    , cardano-ledger-conway:testlib
     , cardano-ledger-core
     , cardano-ledger-dijkstra
-    , cardano-ledger-mary
+    , cardano-ledger-mary:testlib
     , cardano-ledger-shelley
     , cardano-slotting
     , cardano-strict-containers

--- a/cardano-balance-tx.cabal
+++ b/cardano-balance-tx.cabal
@@ -67,19 +67,19 @@ library
     , bytestring                   >=0.10.6    && <0.13
     , cardano-addresses            >=4.0.2     && <4.1
     , cardano-coin-selection
-    , cardano-crypto-class         ^>=2.2.3
-    , cardano-ledger-allegra       >=1.8.0.0   && <1.9
-    , cardano-ledger-alonzo        >=1.14.0.0  && <1.15
-    , cardano-ledger-api           >=1.12.1.0  && <1.13
-    , cardano-ledger-babbage       >=1.12.0.0  && <1.13
+    , cardano-crypto-class         >=2.3.1     && <2.4
+    , cardano-ledger-allegra       >=1.9.0.0   && <1.10
+    , cardano-ledger-alonzo        >=1.15.0.0  && <1.16
+    , cardano-ledger-api           >=1.13.0.0  && <1.14
+    , cardano-ledger-babbage       >=1.13.0.0  && <1.14
     , cardano-ledger-binary
-    , cardano-ledger-conway        >=1.20.0.0  && <1.21
-    , cardano-ledger-dijkstra      >=0.1.0.0   && <0.2
-    , cardano-ledger-core          >=1.18.0.0  && <1.19
-    , cardano-ledger-mary          >=1.9.0.0   && <1.10
-    , cardano-ledger-shelley       >=1.17.0.0  && <1.18
-    , cardano-slotting             >=0.2.0.0   && <0.3
-    , cardano-strict-containers    >=0.1.3.0   && <0.2
+    , cardano-ledger-conway        >=1.21.0.0  && <1.22
+    , cardano-ledger-dijkstra      >=0.2.0.0   && <0.3
+    , cardano-ledger-core          >=1.19.0.0  && <1.20
+    , cardano-ledger-mary          >=1.10.0.0  && <1.11
+    , cardano-ledger-shelley       >=1.18.0.0  && <1.19
+    , cardano-slotting             >=0.2.1.0   && <0.3
+    , cardano-strict-containers    >=0.1.6.0   && <0.2
     , cborg                        >=0.2.1     && <0.3
     , containers                   >=0.5       && <0.8
     , deepseq                      >=1.4.4     && <1.6
@@ -91,8 +91,7 @@ library
     , MonadRandom                  >=0.6       && <0.7
     , monoid-subclasses            >=1.2.5.1   && <1.3
     , nonempty-containers          >=0.3.4.5   && <0.4
-    , ouroboros-consensus          >=0.30.0.0  && <0.31
-    , ouroboros-consensus-cardano  >=0.26.0.0  && <0.27
+    , ouroboros-consensus          >=1.0.0.0   && <1.1
     , pretty-simple                >=4.1.2.0   && <4.2
     , QuickCheck                   >=2.14      && <2.16.0
     , serialise                    >=0.2.6.1   && <0.3
@@ -134,17 +133,15 @@ test-suite unit
     , cardano-crypto-class
     , cardano-crypto-wrapper
     , cardano-ledger-alonzo
-    , cardano-ledger-alonzo:testlib
+    , cardano-ledger-alonzo-test
     , cardano-ledger-api
     , cardano-ledger-babbage
-    , cardano-ledger-babbage:testlib
     , cardano-ledger-binary
     , cardano-ledger-byron
     , cardano-ledger-conway
-    , cardano-ledger-conway:testlib
     , cardano-ledger-dijkstra
     , cardano-ledger-core
-    , cardano-ledger-mary:testlib
+    , cardano-ledger-shelley-ma-test
     , cardano-ledger-shelley
     , cardano-slotting
     , cardano-strict-containers
@@ -168,7 +165,7 @@ test-suite unit
     , nonempty-containers
     , OddWord
     , ouroboros-consensus
-    , ouroboros-network-api
+    , ouroboros-network
     , pretty-show
     , QuickCheck
     , quickcheck-classes

--- a/cardano-balance-tx.cabal
+++ b/cardano-balance-tx.cabal
@@ -67,19 +67,19 @@ library
     , bytestring                 >=0.10.6   && <0.13
     , cardano-addresses          >=4.0.2    && <4.1
     , cardano-coin-selection
-    , cardano-crypto-class       >=2.3.1    && <2.4
-    , cardano-ledger-allegra     >=1.9.0.0  && <1.10
-    , cardano-ledger-alonzo      >=1.15.0.0 && <1.16
-    , cardano-ledger-api         >=1.13.0.0 && <1.14
-    , cardano-ledger-babbage     >=1.13.0.0 && <1.14
+    , cardano-crypto-class
+    , cardano-ledger-allegra
+    , cardano-ledger-alonzo
+    , cardano-ledger-api
+    , cardano-ledger-babbage
     , cardano-ledger-binary
-    , cardano-ledger-conway      >=1.21.0.0 && <1.22
-    , cardano-ledger-core        >=1.19.0.0 && <1.20
-    , cardano-ledger-dijkstra    >=0.2.0.0  && <0.3
-    , cardano-ledger-mary        >=1.10.0.0 && <1.11
-    , cardano-ledger-shelley     >=1.18.0.0 && <1.19
+    , cardano-ledger-conway
+    , cardano-ledger-core
+    , cardano-ledger-dijkstra
+    , cardano-ledger-mary
+    , cardano-ledger-shelley
     , cardano-protocol-tpraos    >=1.5.0.0  && <1.6
-    , cardano-slotting           >=0.2.1.0  && <0.3
+    , cardano-slotting
     , cardano-strict-containers  >=0.1.6.0  && <0.2
     , cborg                      >=0.2.1    && <0.3
     , containers                 >=0.5      && <0.8
@@ -92,7 +92,7 @@ library
     , MonadRandom                >=0.6      && <0.7
     , monoid-subclasses          >=1.2.5.1  && <1.3
     , nonempty-containers        >=0.3.4.5  && <0.4
-    , ouroboros-consensus        >=1.0.0.0  && <1.1
+    , ouroboros-consensus
     , pretty-simple              >=4.1.2.0  && <4.2
     , QuickCheck                 >=2.14     && <2.16.0
     , serialise                  >=0.2.6.1  && <0.3

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1771047846,
-        "narHash": "sha256-1ebLeCCnwuU1y/nLbBQTXtQUK1OBQmxclnJZbfffzG0=",
+        "lastModified": 1774292745,
+        "narHash": "sha256-m/+P0W4C6tYojUPSq8tY4Dwan14bDA2aXbkctWTonj8=",
         "owner": "intersectmbo",
         "repo": "cardano-haskell-packages",
-        "rev": "ac46ea63b0d5e6137d2b17ae1bfa71a0b0983c3e",
+        "rev": "887d73ce434831e3a67df48e070f4f979b3ac5a6",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1774292745,
-        "narHash": "sha256-m/+P0W4C6tYojUPSq8tY4Dwan14bDA2aXbkctWTonj8=",
+        "lastModified": 1776203472,
+        "narHash": "sha256-husRfOULFemi5q+JpO7deykZxTKSIz0E4fCR387aO3Y=",
         "owner": "intersectmbo",
         "repo": "cardano-haskell-packages",
-        "rev": "887d73ce434831e3a67df48e070f4f979b3ac5a6",
+        "rev": "3831817e4131b3ef5fe262e3f853b87bec8a24a0",
         "type": "github"
       },
       "original": {
@@ -47,23 +47,6 @@
         "owner": "supranational",
         "ref": "v0.3.14",
         "repo": "blst",
-        "type": "github"
-      }
-    },
-    "cabal-32": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1603716527,
-        "narHash": "sha256-X0TFfdD4KZpwl0Zr6x+PLxUt/VyKQfX7ylXHdmZIL+w=",
-        "owner": "haskell",
-        "repo": "cabal",
-        "rev": "48bf10787e27364730dd37a42b603cee8d6af7ee",
-        "type": "github"
-      },
-      "original": {
-        "owner": "haskell",
-        "ref": "3.2",
-        "repo": "cabal",
         "type": "github"
       }
     },
@@ -174,11 +157,11 @@
     "hackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1771029998,
-        "narHash": "sha256-n2OPFR7msGuDHi03FsSSTkw5uyO6/odXCH42033/Yjs=",
+        "lastModified": 1776301467,
+        "narHash": "sha256-1dthf9sMMjfFCRXjkM1iftdtsx17O3H/o/JrChA7AP4=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "26b99ff043af013c9c1c929976ce7dcd8f04d3d7",
+        "rev": "055728d28f056b4f277f1b2d6e217afda0c8208a",
         "type": "github"
       },
       "original": {
@@ -190,11 +173,11 @@
     "hackage-for-stackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1771029224,
-        "narHash": "sha256-UxOihzZ6YEShBKopmID8yN92XUVWnBk1yksMRSwdiZ4=",
+        "lastModified": 1776300248,
+        "narHash": "sha256-A1CmQJgfPMn8/8yRt/bBUrcgZw5/zQrF2mzjEPOfcGQ=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "0e5a1b2997fd0a98c75ce1dd2f1d1bb282ac979e",
+        "rev": "4b7ee0b8683a29156aafcd541065ab8da4bd2ab8",
         "type": "github"
       },
       "original": {
@@ -223,7 +206,6 @@
     "haskellNix": {
       "inputs": {
         "HTTP": "HTTP",
-        "cabal-32": "cabal-32",
         "cabal-34": "cabal-34",
         "cabal-36": "cabal-36",
         "cardano-shell": "cardano-shell",
@@ -262,11 +244,11 @@
         "stackage": "stackage"
       },
       "locked": {
-        "lastModified": 1771030507,
-        "narHash": "sha256-mwSXjx4CSVUEIizqIHETID76Mzm19mCvNjDlcfiGptY=",
+        "lastModified": 1776301808,
+        "narHash": "sha256-vvv0FZpbEat6JmFAa7Be5aHbw9cmClDSe1Pfeuhqroc=",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "a1dc76749f86cb85e71b87fe5d1438744ecdf531",
+        "rev": "1ea973a029b3e3d402151fba198068852190802c",
         "type": "github"
       },
       "original": {
@@ -554,11 +536,11 @@
     "iserv-proxy": {
       "flake": false,
       "locked": {
-        "lastModified": 1770174258,
-        "narHash": "sha256-x6QYupvHZM7rRpVO4AIC5gUWFprFQ59A95FPC7/Owjg=",
+        "lastModified": 1775620557,
+        "narHash": "sha256-10x8/G0x3eR/++XRHPx4MBuqlnc6+N+ajIxXyLkG+nU=",
         "owner": "stable-haskell",
         "repo": "iserv-proxy",
-        "rev": "91ef7ffdeedfb141a4d69dcf9e550abe3e1160c6",
+        "rev": "3f7b2815307c20a0dfd816bdf4a39ab86af3e0d4",
         "type": "github"
       },
       "original": {
@@ -799,11 +781,11 @@
     "stackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1770769351,
-        "narHash": "sha256-f8WSq0lEB+R1h78Rr+J1U4El6m33rR7zskrHREZqPgk=",
+        "lastModified": 1776299261,
+        "narHash": "sha256-E1bVIxetWmgBKGiMgpmO0H4QGcc0Wl0oVQ4MXBMZWOQ=",
         "owner": "input-output-hk",
         "repo": "stackage.nix",
-        "rev": "f656c6e52f1efe33648c6433f30011a4d5e0abd0",
+        "rev": "7a1de4e5b353a0ca0e3b3ea436c3b26432c1dc49",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -35,7 +35,7 @@
           inherit system;
         };
         project = import ./nix/project.nix {
-          indexState = "2026-02-14T00:39:24Z";
+          indexState = "2026-03-26T20:21:33Z";
           inherit pkgs CHaP;
           mkdocs = mkdocs.packages.${system};
         };

--- a/flake.nix
+++ b/flake.nix
@@ -35,7 +35,7 @@
           inherit system;
         };
         project = import ./nix/project.nix {
-          indexState = "2025-10-01T00:00:00Z";
+          indexState = "2026-02-14T00:39:24Z";
           inherit pkgs CHaP;
           mkdocs = mkdocs.packages.${system};
         };

--- a/lib/Cardano/Balance/Tx/Balance.hs
+++ b/lib/Cardano/Balance/Tx/Balance.hs
@@ -202,9 +202,6 @@ import Control.Monad.Trans.State
     ( runState
     , state
     )
-import Data.Bits
-    ( Bits
-    )
 import Data.Function
     ( on
     , (&)
@@ -258,9 +255,6 @@ import Fmt
 import GHC.Generics
     ( Generic
     )
-import GHC.Stack
-    ( HasCallStack
-    )
 import Numeric.Natural
     ( Natural
     )
@@ -283,6 +277,7 @@ import qualified Cardano.CoinSelection.Types.TokenBundle as CS
 import qualified Cardano.CoinSelection.UTxOIndex as UTxOIndex
 import qualified Cardano.CoinSelection.UTxOSelection as UTxOSelection
 import qualified Cardano.Ledger.Core as Core
+import qualified Cardano.Ledger.Dijkstra.Scripts as DijkstraScripts
 import qualified Cardano.Ledger.Val as Val
     ( coin
     )
@@ -1078,9 +1073,11 @@ selectAssets
                         ]
                         <\> boringFee
                 , maximumCollateralInputCount =
-                    unsafeIntCast @Natural @Int $ pp ^. ppMaxCollateralInputsL
+                    fromMaybe
+                        (error "maximumCollateralInputCount exceeds Int range")
+                        (intCastMaybe $ pp ^. ppMaxCollateralInputsL)
                 , minimumCollateralPercentage =
-                    pp ^. ppCollateralPercentageL
+                    fromIntegral $ pp ^. ppCollateralPercentageL
                 , maximumLengthChangeAddress =
                     Convert.fromLedgerAddress changeGen.maxLengthChangeAddress
                 }
@@ -1241,14 +1238,6 @@ assignChangeAddresses (ChangeAddressGen genChange _) sel = runState $ do
         pure $ W.TxOut (Convert.fromLedgerAddress addr) bundle
     pure $ set #change changeOuts sel
 
-unsafeIntCast
-    :: (HasCallStack, Integral a, Integral b, Bits a, Bits b, Show a)
-    => a
-    -> b
-unsafeIntCast x = fromMaybe err $ intCastMaybe x
-  where
-    err = error $ "unsafeIntCast failed for " <> show x
-
 mergeSignedValue :: (W.TokenBundle, W.TokenBundle) -> Value
 mergeSignedValue (bNegative, bPositive) = vNegative <> vPositive
   where
@@ -1368,7 +1357,10 @@ updateTx tx extraContent = do
         -> Core.Script era
     toLedgerScript s = \case
         RecentEraConway -> NativeScript $ Convert.toLedgerTimelockScript s
-        RecentEraDijkstra -> NativeScript $ Convert.toLedgerTimelockScript s
+        RecentEraDijkstra ->
+            NativeScript $
+                DijkstraScripts.upgradeTimelock $
+                    Convert.toLedgerTimelockScript s
 
 modifyShelleyTxBody
     :: forall era

--- a/lib/Cardano/Balance/Tx/Balance/TokenBundleSize.hs
+++ b/lib/Cardano/Balance/Tx/Balance/TokenBundleSize.hs
@@ -59,7 +59,7 @@ mkTokenBundleSizeAssessor pp = TokenBundleSizeAssessor $ \csBundle ->
             else TokenBundleSizeWithinLimit
   where
     maxValSize :: W.TxSize
-    maxValSize = W.TxSize $ pp ^. ppMaxValSizeL
+    maxValSize = W.TxSize $ fromIntegral $ pp ^. ppMaxValSizeL
 
     ver :: Version
     ver = pvMajor $ pp ^. ppProtocolVersionL

--- a/lib/Cardano/Balance/Tx/Eras.hs
+++ b/lib/Cardano/Balance/Tx/Eras.hs
@@ -85,6 +85,9 @@ import qualified Cardano.Ledger.Alonzo.Core as Alonzo
 import qualified Cardano.Ledger.Api as Ledger
 import qualified Cardano.Ledger.Babbage.TxBody as Babbage
 import qualified Cardano.Ledger.Core as Core
+import Cardano.Ledger.MemoBytes
+    ( EqRaw
+    )
 import qualified Cardano.Ledger.Shelley.UTxO as Shelley
 import qualified Data.Set as Set
 
@@ -196,6 +199,11 @@ type RecentEraConstraints era =
     , Show (AlonzoScript era)
     , EraPlutusContext era
     , AllegraEraScript era
+    , -- EqRaw (NativeScript era) is not a superclass of EraScript but is
+      -- required by downstream consumers (cardano-wallet) when GHC resolves
+      -- the full superclass chain through EraTx/EraTxWits/EraScript.
+      -- All recent eras (Conway, Dijkstra) have this instance.
+      EqRaw (Core.NativeScript era)
     )
 
 instance IsRecentEra Conway where

--- a/lib/Cardano/Balance/Tx/Eras.hs
+++ b/lib/Cardano/Balance/Tx/Eras.hs
@@ -33,7 +33,6 @@ module Cardano.Balance.Tx.Eras
 
 import Cardano.Ledger.Allegra.Scripts
     ( AllegraEraScript
-    , Timelock
     )
 import Cardano.Ledger.Alonzo.Plutus.Context
     ( EraPlutusContext

--- a/lib/Cardano/Balance/Tx/Eras.hs
+++ b/lib/Cardano/Balance/Tx/Eras.hs
@@ -188,18 +188,15 @@ type RecentEraConstraints era =
     , ScriptsNeeded era ~ AlonzoScriptsNeeded era
     , AlonzoEraScript era
     , Eq (Core.TxOut era)
-    , Eq (Core.Tx era)
     , Babbage.BabbageEraTxBody era
     , Alonzo.AlonzoEraTxBody era
     , Shelley.EraUTxO era
     , Core.EraTxCert era
     , Show (Core.TxOut era)
-    , Show (Core.Tx era)
     , Show (Core.PParams era)
     , Show (AlonzoScript era)
     , EraPlutusContext era
     , AllegraEraScript era
-    , Core.NativeScript era ~ Timelock era
     )
 
 instance IsRecentEra Conway where

--- a/lib/Cardano/Balance/Tx/Gen.hs
+++ b/lib/Cardano/Balance/Tx/Gen.hs
@@ -33,7 +33,6 @@ import Cardano.Ledger.Api
     )
 import Cardano.Ledger.Babbage.PParams
     ( BabbagePParams (..)
-    , CoinPerByte (..)
     )
 import Cardano.Ledger.BaseTypes
     ( BoundedRational (..)
@@ -44,6 +43,7 @@ import Cardano.Ledger.BaseTypes
     )
 import Cardano.Ledger.Coin
     ( Coin (..)
+    , CoinPerByte (..)
     , CompactForm (CompactCoin)
     )
 import Cardano.Ledger.Conway.PParams
@@ -172,9 +172,9 @@ mockPParams = case recentEra @era of
     babbagePParams :: BabbagePParams Identity BabbageEra
     babbagePParams =
         BabbagePParams
-            { bppMinFeeA = Coin 44
+            { bppTxFeePerByte = CoinPerByte (CompactCoin 44)
             , -- \^ The linear factor for the minimum fee calculation
-              bppMinFeeB = Coin 155_381
+              bppTxFeeFixed = CompactCoin 155_381
             , -- \^ The constant factor for the minimum fee calculation
               bppMaxBBSize = 100_000
             , -- \^ Maximal block body size
@@ -182,7 +182,7 @@ mockPParams = case recentEra @era of
             , -- \^ Maximal transaction size
               bppMaxBHSize = 1_100
             , -- \^ Maximal block header size
-              bppKeyDeposit = Coin 2_000_000
+              bppKeyDeposit = CompactCoin 2_000_000
             , -- \^ The amount of a key registration deposit
               bppPoolDeposit = CompactCoin 500_000_000
             , -- \^ The amount of a pool registration deposit
@@ -199,9 +199,9 @@ mockPParams = case recentEra @era of
             , -- \^ Treasury expansion
               bppProtocolVersion = ProtVer (natVersion @6) 0
             , -- \^ Protocol version
-              bppMinPoolCost = Coin 170_000_000
+              bppMinPoolCost = CompactCoin 170_000_000
             , -- \^ Minimum Stake Pool Cost
-              bppCoinsPerUTxOByte = CoinPerByte (Coin 4_310)
+              bppCoinsPerUTxOByte = CoinPerByte (CompactCoin 4_310)
             , -- \^ Cost in lovelace per byte of UTxO storage (instead of bppCoinsPerUTxOByte)
               bppCostModels = babbageCostModels
             , -- \^ Cost models for non-native script languages

--- a/lib/Cardano/Balance/Tx/Redeemers.hs
+++ b/lib/Cardano/Balance/Tx/Redeemers.hs
@@ -37,13 +37,13 @@ import Cardano.Balance.Tx.Tx
     ( PParams
     , PolicyId
     , RewardAccount
+    , Tx
     , TxIn
     , UTxO
     )
 import Cardano.Ledger.Api
     ( AsItem (..)
     , TransactionScriptFailure
-    , Tx
     , bodyTxL
     , rdmrsTxWitsL
     , scriptIntegrityHashTxBodyL

--- a/lib/Cardano/Balance/Tx/Sign.hs
+++ b/lib/Cardano/Balance/Tx/Sign.hs
@@ -1,9 +1,11 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE ExplicitNamespaces #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TupleSections #-}
 {-# LANGUAGE TypeApplications #-}
@@ -34,7 +36,8 @@ module Cardano.Balance.Tx.Sign
 where
 
 import Cardano.Balance.Tx.Eras
-    ( IsRecentEra (..)
+    ( Dijkstra
+    , IsRecentEra (..)
     , RecentEra (..)
     )
 import Cardano.Balance.Tx.Primitive
@@ -43,18 +46,15 @@ import Cardano.Balance.Tx.Primitive
 import Cardano.Balance.Tx.Tx
     ( KeyWitnessCounts (..)
     , PParams
+    , RewardAccount
     , Script
+    , StakeCredential
     , Tx
     , TxIn
     , UTxO
     , feeOfBytes
     , getFeePerByte
-    )
-import Cardano.Ledger.Address
-    ( RewardAccount (..)
-    )
-import Cardano.Ledger.Allegra.Scripts
-    ( Timelock
+    , pattern RewardAccount
     )
 import Cardano.Ledger.Api
     ( Addr (..)
@@ -77,7 +77,9 @@ import Cardano.Ledger.Coin
     )
 import Cardano.Ledger.Credential
     ( Credential (..)
-    , StakeCredential
+    )
+import Cardano.Ledger.MemoBytes
+    ( getMemoRawType
     )
 import Cardano.Ledger.State
     ( EraUTxO (getScriptsHashesNeeded, getScriptsNeeded)
@@ -122,6 +124,7 @@ import qualified Cardano.Ledger.Alonzo.Core as Alonzo
 import qualified Cardano.Ledger.Alonzo.Scripts as Alonzo
 import qualified Cardano.Ledger.Api as Ledger
 import qualified Cardano.Ledger.Conway.TxCert as Conway
+import qualified Cardano.Ledger.Dijkstra.Scripts as DijkstraScripts
 import qualified Cardano.Ledger.Dijkstra.TxCert as Dijkstra
 import qualified Data.Foldable as F
 import qualified Data.List as L
@@ -263,7 +266,7 @@ estimateKeyWitnessCounts utxo tx timelockKeyWitCounts =
             :: Map (ScriptHash) Natural
         upperBoundEstimatedTimelockKeyWitnessCounts =
             Map.mapMaybe
-                ( fmap (estimateMaxWitnessRequiredPerInput . toCAScript)
+                ( fmap estimateMaxWitnessRequiredPerNativeScript
                     . toTimelockScript
                 )
                 -- TODO [ADP-2675]
@@ -319,13 +322,39 @@ estimateKeyWitnessCounts utxo tx timelockKeyWitCounts =
             KeyHashObj _ -> 1
             ScriptHashObj _ -> 0
 
-    toCAScript = Convert.toWalletScript (const dummyKeyRole)
-      where
-        dummyKeyRole = CA.Payment
+    estimateMaxWitnessRequiredPerNativeScript
+        :: Ledger.NativeScript era
+        -> Natural
+    estimateMaxWitnessRequiredPerNativeScript = case recentEra @era of
+        RecentEraConway ->
+            estimateMaxWitnessRequiredPerInput
+                . Convert.toWalletScript (const CA.Payment)
+        RecentEraDijkstra ->
+            estimateMaxWitnessRequiredPerDijkstraScript
+
+    estimateMaxWitnessRequiredPerDijkstraScript
+        :: DijkstraScripts.DijkstraNativeScript Dijkstra
+        -> Natural
+    estimateMaxWitnessRequiredPerDijkstraScript script =
+        case getMemoRawType script of
+            DijkstraScripts.DijkstraRequireSignature _ ->
+                1
+            DijkstraScripts.DijkstraRequireAllOf scripts ->
+                sum $ estimateMaxWitnessRequiredPerDijkstraScript <$> scripts
+            DijkstraScripts.DijkstraRequireAnyOf scripts ->
+                sum $ estimateMaxWitnessRequiredPerDijkstraScript <$> scripts
+            DijkstraScripts.DijkstraRequireMOf _ scripts ->
+                sum $ estimateMaxWitnessRequiredPerDijkstraScript <$> scripts
+            DijkstraScripts.DijkstraTimeStart _ ->
+                0
+            DijkstraScripts.DijkstraTimeExpire _ ->
+                0
+            DijkstraScripts.DijkstraRequireGuard _ ->
+                0
 
     toTimelockScript
         :: Ledger.Script era
-        -> Maybe (Timelock era)
+        -> Maybe (Ledger.NativeScript era)
     toTimelockScript (Alonzo.NativeScript timelock) = Just timelock
     toTimelockScript (Alonzo.PlutusScript _) = Nothing
 

--- a/lib/Cardano/Balance/Tx/Tx.hs
+++ b/lib/Cardano/Balance/Tx/Tx.hs
@@ -86,6 +86,7 @@ module Cardano.Balance.Tx.Tx
 
       -- ** Rewards
     , RewardAccount
+    , pattern RewardAccount
     , StakeCredential
 
       -- ** Script
@@ -125,15 +126,13 @@ import Cardano.Crypto.Hash
     ( Hash (UnsafeHash)
     )
 import Cardano.Ledger.Allegra.Scripts
-    ( translateTimelock
+    ( Timelock
     )
 import Cardano.Ledger.Alonzo.Scripts
     ( AlonzoScript (..)
     )
 import Cardano.Ledger.Api
-    ( Tx
-    , TxBody
-    , TxOut
+    ( TxOut
     , coinTxOutL
     , eraProtVerLow
     , upgradeTxOut
@@ -145,7 +144,8 @@ import Cardano.Ledger.Babbage.TxBody
     ( BabbageTxOut (..)
     )
 import Cardano.Ledger.BaseTypes
-    ( ProtVer (..)
+    ( Network
+    , ProtVer (..)
     , StrictMaybe (..)
     , Version
     , maybeToStrictMaybe
@@ -153,6 +153,10 @@ import Cardano.Ledger.BaseTypes
     )
 import Cardano.Ledger.Coin
     ( Coin (..)
+    , CoinPerByte (..)
+    )
+import Cardano.Ledger.Compactible
+    ( fromCompact
     )
 import Cardano.Ledger.Conway.PParams
     ( ppDRepDepositL
@@ -174,6 +178,9 @@ import Cardano.Ledger.Mary
 import Cardano.Ledger.Mary.Value
     ( AssetName
     )
+import Cardano.Ledger.MemoBytes
+    ( getMemoRawType
+    )
 import Cardano.Ledger.Plutus.Data
     ( BinaryData
     , Datum (..)
@@ -181,6 +188,9 @@ import Cardano.Ledger.Plutus.Data
 import Cardano.Ledger.Val
     ( coin
     , modifyCoin
+    )
+import Cardano.Protocol.Crypto
+    ( StandardCrypto
     )
 import Control.Arrow
     ( second
@@ -212,15 +222,13 @@ import GHC.Stack
 import Numeric.Natural
     ( Natural
     )
-import Ouroboros.Consensus.Shelley.Eras
-    ( StandardCrypto
-    )
 import Prelude
 
 import qualified Cardano.Balance.Tx.Primitive as W
 import qualified Cardano.Balance.Tx.Primitive.Convert as Convert
 import qualified Cardano.Crypto.Hash.Class as Crypto
 import qualified Cardano.Ledger.Address as Ledger
+import qualified Cardano.Ledger.Allegra.Scripts as Allegra
 import qualified Cardano.Ledger.Alonzo.Core as Alonzo
 import qualified Cardano.Ledger.Alonzo.Scripts as Alonzo
 import qualified Cardano.Ledger.Api as Ledger
@@ -229,7 +237,8 @@ import qualified Cardano.Ledger.Babbage.TxBody as Babbage
 import qualified Cardano.Ledger.Binary as Binary
 import qualified Cardano.Ledger.Core as Core
 import qualified Cardano.Ledger.Credential as Core
-import qualified Cardano.Ledger.Keys as Ledger
+import qualified Cardano.Ledger.Dijkstra.Scripts as DijkstraScripts
+import qualified Cardano.Ledger.Keys as Keys
 import qualified Cardano.Ledger.Mary.Value as Value
 import qualified Cardano.Ledger.Plutus.Data as Alonzo
 import qualified Cardano.Ledger.Shelley.UTxO as Shelley
@@ -260,6 +269,9 @@ instance Monoid KeyWitnessCounts where
 -- TxIn
 --------------------------------------------------------------------------------
 
+type Tx era = Core.Tx Core.TopTx era
+type TxBody era = Core.TxBody Core.TopTx era
+
 type TxIn = Ledger.TxIn
 
 -- | Useful for testing
@@ -281,10 +293,17 @@ type TxOutInBabbage = Babbage.BabbageTxOut Conway
 
 type Address = Ledger.Addr
 
-type RewardAccount = Ledger.RewardAccount
+type RewardAccount = Ledger.AccountAddress
 type Script = AlonzoScript
 type ScriptHash = Core.ScriptHash
 type Value = MaryValue
+
+pattern RewardAccount
+    :: Network
+    -> StakeCredential
+    -> RewardAccount
+pattern RewardAccount network credential =
+    Ledger.AccountAddress network (Ledger.AccountId credential)
 
 unsafeAddressFromBytes :: ByteString -> Address
 unsafeAddressFromBytes bytes = case Ledger.decodeAddr bytes of
@@ -335,6 +354,7 @@ wrapTxOutInRecentEra out = case recentEra @era of
 
 data ErrInvalidTxOutInEra
     = InlinePlutusV4ScriptNotSupportedInConway
+    | GuardNativeScriptNotSupportedInConway
     deriving (Show, Eq)
 
 unwrapTxOutInRecentEra
@@ -375,9 +395,33 @@ recentEraToConwayTxOut (TxOutInRecentEra addr val datum mscript) =
         -> Either ErrInvalidTxOutInEra (AlonzoScript Conway)
     downgradeScript = \case
         Alonzo.NativeScript timelockEra ->
-            pure $ Alonzo.NativeScript (translateTimelock timelockEra)
+            Alonzo.NativeScript <$> downgradeNativeScript timelockEra
         PlutusScript s ->
             PlutusScript <$> downgradePlutusScript s
+
+    downgradeNativeScript
+        :: DijkstraScripts.DijkstraNativeScript Dijkstra
+        -> Either ErrInvalidTxOutInEra (Timelock Conway)
+    downgradeNativeScript =
+        \case
+            script -> case getMemoRawType script of
+                DijkstraScripts.DijkstraRequireSignature keyHash ->
+                    Right $ Allegra.mkRequireSignatureTimelock keyHash
+                DijkstraScripts.DijkstraRequireAllOf scripts ->
+                    Allegra.mkRequireAllOfTimelock
+                        <$> traverse downgradeNativeScript scripts
+                DijkstraScripts.DijkstraRequireAnyOf scripts ->
+                    Allegra.mkRequireAnyOfTimelock
+                        <$> traverse downgradeNativeScript scripts
+                DijkstraScripts.DijkstraRequireMOf required scripts ->
+                    Allegra.mkRequireMOfTimelock required
+                        <$> traverse downgradeNativeScript scripts
+                DijkstraScripts.DijkstraTimeStart slotNo ->
+                    Right $ Allegra.RequireTimeStart slotNo
+                DijkstraScripts.DijkstraTimeExpire slotNo ->
+                    Right $ Allegra.RequireTimeExpire slotNo
+                DijkstraScripts.DijkstraRequireGuard _guard ->
+                    Left GuardNativeScriptNotSupportedInConway
 
     downgradePlutusScript
         :: PlutusScript Dijkstra
@@ -549,9 +593,11 @@ getFeePerByte
     -> FeePerByte
 getFeePerByte pp =
     unsafeCoinToFee $
-        case recentEra @era of
-            RecentEraConway -> pp ^. Core.ppMinFeeAL
-            RecentEraDijkstra -> pp ^. Core.ppMinFeeAL
+        fromCompact $
+            unCoinPerByte $
+                case recentEra @era of
+                    RecentEraConway -> pp ^. Core.ppTxFeePerByteL
+                    RecentEraDijkstra -> pp ^. Core.ppTxFeePerByteL
   where
     unsafeCoinToFee :: Coin -> FeePerByte
     unsafeCoinToFee =
@@ -612,9 +658,6 @@ evaluateTransactionBalance pp depositLookup =
     -- TODO [ADP-3404] Query actual value of deposit
     --
     -- https://cardanofoundation.atlassian.net/browse/ADP-3404
-    dRepDepositAssumeCurrent
-        :: Core.Credential 'Ledger.DRepRole
-        -> Maybe Coin
     dRepDepositAssumeCurrent _drepCred = case recentEra @era of
         RecentEraConway -> Just $ pp ^. ppDRepDepositL
         RecentEraDijkstra -> Just $ pp ^. ppDRepDepositL
@@ -628,9 +671,6 @@ evaluateTransactionBalance pp depositLookup =
     -- TODO [ADP-3274] Query actual registration status
     --
     -- https://cardanofoundation.atlassian.net/browse/ADP-3274
-    assumePoolIsReg
-        :: Ledger.KeyHash 'Ledger.StakePool
-        -> Bool
     assumePoolIsReg _keyHash = True
 
 --------------------------------------------------------------------------------
@@ -649,4 +689,4 @@ pattern PolicyId h = Value.PolicyID h
 -- Stake Credential
 --------------------------------------------------------------------------------
 
-type StakeCredential = Core.StakeCredential
+type StakeCredential = Core.Credential Keys.Staking

--- a/lib/Cardano/Balance/Tx/TxWithUTxO.hs
+++ b/lib/Cardano/Balance/Tx/TxWithUTxO.hs
@@ -23,6 +23,7 @@ import Cardano.Balance.Tx.Eras
     )
 import Cardano.Balance.Tx.Tx
     ( Tx
+    , TxBody
     , TxIn
     , UTxO (UTxO)
     )
@@ -30,7 +31,7 @@ import Cardano.Ledger.Api
     ( AlonzoEraTxBody (collateralInputsTxBodyL)
     , BabbageEraTxBody (referenceInputsTxBodyL)
     , EraTx (bodyTxL)
-    , EraTxBody (TxBody, inputsTxBodyL)
+    , EraTxBody (inputsTxBodyL)
     )
 import Cardano.Ledger.Api.Tx.Body
     ( allInputsTxBodyF

--- a/nix/project.nix
+++ b/nix/project.nix
@@ -9,6 +9,13 @@ let
       fourmolu = { index-state = indexState; };
       hlint = { index-state = indexState; };
     };
+    additional = hsPkgs:
+      with hsPkgs; [
+        cardano-ledger-alonzo.components.sublibs.testlib
+        cardano-ledger-babbage.components.sublibs.testlib
+        cardano-ledger-conway.components.sublibs.testlib
+        cardano-ledger-mary.components.sublibs.testlib
+      ];
     # GHC 9.12.2 haddock panics on tyConStupidTheta; disable until fixed
     withHoogle = false;
     buildInputs = [

--- a/nix/project.nix
+++ b/nix/project.nix
@@ -9,7 +9,8 @@ let
       fourmolu = { index-state = indexState; };
       hlint = { index-state = indexState; };
     };
-    withHoogle = true;
+    # GHC 9.12.2 haddock panics on tyConStupidTheta; disable until fixed
+    withHoogle = false;
     buildInputs = [
       pkgs.just
       pkgs.nixfmt-classic

--- a/specs/003-bump-node-10-7-0/data-model.md
+++ b/specs/003-bump-node-10-7-0/data-model.md
@@ -1,0 +1,28 @@
+# Data Model: Bump cardano-node to 10.7.0
+
+## Recent Era Native Script Support
+
+- **Conway native script**
+  - Existing representation remains timelock-compatible.
+  - Used where recent-era helpers still produce ledger-native scripts.
+- **Dijkstra native script**
+  - Uses `DijkstraNativeScript`.
+  - Requires explicit era-aware conversion instead of a shared `Timelock`
+    equality constraint.
+
+## Test Generator Support
+
+- **Ledger Arbitrary source**
+  - Existing tests rely on upstream orphan `Arbitrary` instances.
+  - The source package changed, so the project may need local orphan
+    imports or replacement generators for affected ledger types.
+
+## Migration State
+
+- **Current bump baseline**
+  - Dependency bounds and flake inputs already point to `10.7.0`.
+  - Recent-era constraints were partially updated in `Eras.hs`.
+- **Remaining state**
+  - Library build still trips over stale imports/constraints.
+  - Test build is expected to fail on removed `testlib` sublibraries
+    after library compatibility is restored.

--- a/specs/003-bump-node-10-7-0/plan.md
+++ b/specs/003-bump-node-10-7-0/plan.md
@@ -1,0 +1,74 @@
+# Implementation Plan: Bump cardano-node to 10.7.0
+
+**Branch**: `003-bump-node-10-7-0` | **Date**: 2026-04-15 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/003-bump-node-10-7-0/spec.md`
+
+## Summary
+
+Finish the existing dependency bump by addressing the remaining source
+compatibility breaks introduced by ledger `1.19`. The work proceeds in
+three steps: stabilize the recent-era abstractions and native script
+helpers, replace removed upstream test generator dependencies, and then
+resolve any remaining cascading API changes until `cabal build all -O0`
+is clean.
+
+## Technical Context
+
+**Language/Version**: Haskell with GHC 9.12.2 in the project flake
+**Primary Dependencies**: `cardano-ledger-*`, `cardano-addresses`,
+`cardano-coin-selection`, `QuickCheck`
+**Storage**: N/A
+**Testing**: `cabal build` for library and unit test targets
+**Target Platform**: Linux via Nix dev shell
+**Project Type**: Library
+**Performance Goals**: No runtime behavior changes; compile-time
+compatibility only
+**Constraints**: Preserve the two-recent-era model and keep changes
+focused on compatibility with ledger `1.19`
+**Scale/Scope**: 3 library modules, test imports/generators, and any
+follow-on ledger-core API fixes surfaced by the build
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Minimal Dependency Surface | ✅ | Removed testlib packages must not be replaced with broader dependencies |
+| II. Ledger-Native Types | ✅ | Compatibility work stays on ledger-native APIs |
+| III. Era Discipline | ✅ GATE | Era differences must remain localized to `RecentEra`-based branching |
+| IV. Property-Based Testing | ✅ GATE | Test generators must remain self-contained or use supported ledger modules |
+| V. Behavioral Preservation | ✅ | No intended behavior change beyond compilation compatibility |
+| VI. Incremental Migration | ✅ GATE | Each fix should keep the project moving toward a buildable state |
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/003-bump-node-10-7-0/
+├── plan.md
+├── research.md
+├── data-model.md
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+lib/Cardano/Balance/Tx/
+├── Eras.hs
+├── Primitive/Convert.hs
+├── Sign.hs
+└── Balance.hs
+
+test/spec/Cardano/Balance/Tx/
+├── BalanceSpec.hs
+└── TxSpec.hs
+
+cardano-balance-tx.cabal
+```
+
+**Structure Decision**: Apply compatibility fixes in place. No new
+production modules are expected; test support may gain small local
+orphan-instance helpers if upstream generators no longer exist.

--- a/specs/003-bump-node-10-7-0/research.md
+++ b/specs/003-bump-node-10-7-0/research.md
@@ -1,0 +1,30 @@
+# Research: Bump cardano-node to 10.7.0
+
+## Decisions
+
+### Decision: Model native script differences through recent-era branching
+
+- **Why**: Conway and Dijkstra no longer share the same concrete native
+  script type. Dijkstra uses `DijkstraNativeScript`, so the previous
+  blanket `Timelock` equality constraint is no longer valid.
+- **Alternative considered**: Push a more complex typeclass abstraction
+  across all script conversion helpers. Rejected because the project
+  already centralizes era-specific behavior through `RecentEra`, and the
+  constitution prefers localized era branching.
+
+### Decision: Replace removed ledger testlib dependencies locally
+
+- **Why**: The removed `testlib` sublibraries are compatibility debt,
+  not feature work. Local test support is the narrowest fix that
+  satisfies the project constitution.
+- **Alternative considered**: Add new upstream-only dependencies or pin
+  older ledger packages. Rejected because it increases dependency
+  surface and undermines the version bump.
+
+### Decision: Use build-driven migration for cascading ledger-core changes
+
+- **Why**: The handover already identifies likely failure areas, but the
+  full set of required edits depends on actual compiler errors after
+  each compatibility fix.
+- **Alternative considered**: Preemptively rewrite broad areas of code.
+  Rejected because it would create a larger, harder-to-review diff.

--- a/specs/003-bump-node-10-7-0/spec.md
+++ b/specs/003-bump-node-10-7-0/spec.md
@@ -1,0 +1,130 @@
+# Feature Specification: Bump cardano-node to 10.7.0
+
+**Feature Branch**: `003-bump-node-10-7-0`
+**Created**: 2026-04-15
+**Status**: Draft
+**Input**: User description: "Finish the remaining build fixes after the
+cardano-node 10.7.0 dependency bump"
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Library compiles on ledger 1.19 (Priority: P1)
+
+A maintainer upgrades to the `cardano-node 10.7.0` dependency set and
+the library builds successfully against ledger `1.19` without manual
+patching.
+
+**Why this priority**: A non-compiling library blocks all downstream
+use and review. This is the minimum acceptable outcome for the bump.
+
+**Independent Test**: `nix develop --quiet -c cabal build lib:cardano-balance-tx -O0`
+
+**Acceptance Scenarios**:
+
+1. **Given** the `10.7.0` dependency set, **When** the library is
+   built, **Then** recent-era native script conversion and witness
+   estimation compile for both Conway and Dijkstra.
+2. **Given** the updated ledger APIs, **When** the era constraints are
+   checked, **Then** the recent-era abstraction does not depend on the
+   removed `Timelock` equality assumptions.
+
+---
+
+### User Story 2 - Tests compile with current ledger packages (Priority: P2)
+
+A maintainer builds the test suite and no longer depends on removed
+`testlib` sublibraries from `cardano-ledger-babbage` and
+`cardano-ledger-conway`.
+
+**Why this priority**: The migration is incomplete if the library builds
+but test support code still targets removed packages.
+
+**Independent Test**: `nix develop --quiet -c cabal build test:unit -O0`
+
+**Acceptance Scenarios**:
+
+1. **Given** the current ledger package set, **When** test modules are
+   compiled, **Then** all `Arbitrary` imports resolve from supported
+   modules or local generators.
+2. **Given** the project constitution, **When** test generators are
+   updated, **Then** they remain self-contained within the project or
+   supported ledger packages.
+
+---
+
+### User Story 3 - Full project builds cleanly after the bump (Priority: P3)
+
+A reviewer checks the bump branch and sees a clean full build against
+the updated flake and cabal bounds.
+
+**Why this priority**: This is the integration proof that the migration
+is complete and ready for PR review.
+
+**Independent Test**: `nix develop --quiet -c cabal build all -O0`
+
+**Acceptance Scenarios**:
+
+1. **Given** the full package graph, **When** all components are built,
+   **Then** the library and test suite compile without ledger API
+   errors.
+2. **Given** the migration branch, **When** the remaining changes are
+   reviewed, **Then** they are grouped into focused, reviewable
+   increments aligned with the existing bump commits.
+
+### Edge Cases
+
+- What happens when Conway and Dijkstra use different native script
+  representations for the same recent-era helper?
+- What happens when generator instances moved from removed `testlib`
+  sublibraries are no longer exposed anywhere upstream?
+- What happens when ledger `1.19` API changes surface only after an
+  earlier compatibility fix removes the first compilation blocker?
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The library MUST compile against the dependency set pinned
+  for `cardano-node 10.7.0`.
+- **FR-002**: Recent-era native script conversion MUST work for both
+  Conway and Dijkstra, despite Dijkstra using
+  `DijkstraNativeScript` instead of `Timelock`.
+- **FR-003**: The library MUST remove stale imports and constraints that
+  assume `Core.NativeScript era ~ Timelock era` for every recent era.
+- **FR-004**: Test code MUST stop depending on removed
+  `cardano-ledger-babbage:testlib` and
+  `cardano-ledger-conway:testlib` sublibraries.
+- **FR-005**: All remaining ledger-core `1.19` API changes encountered
+  during the bump MUST be adapted in project code.
+- **FR-006**: The migration MUST preserve the two-era discipline defined
+  in the project constitution.
+
+### Key Entities
+
+- **RecentEra**: The project’s closed set of supported ledger eras,
+  currently Conway and Dijkstra.
+- **Native Script Conversion**: The conversion helpers between
+  wallet-level scripts and ledger-native script values.
+- **Ledger Arbitrary Support**: The source of QuickCheck instances used
+  by the unit test suite for ledger types.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: `nix develop --quiet -c cabal build lib:cardano-balance-tx -O0`
+  succeeds.
+- **SC-002**: `nix develop --quiet -c cabal build test:unit -O0`
+  succeeds.
+- **SC-003**: `nix develop --quiet -c cabal build all -O0` succeeds.
+- **SC-004**: No source file imports a removed ledger `testlib`
+  sublibrary.
+
+## Assumptions
+
+- The branch’s existing dependency bumps and CHaP alignment are correct,
+  and the remaining work is strictly source compatibility.
+- The project may replace removed upstream test generators with local
+  orphan instances where necessary, consistent with the constitution.
+- The current PR does not need a broader redesign beyond adapting to the
+  ledger `1.19` API surface.

--- a/specs/003-bump-node-10-7-0/tasks.md
+++ b/specs/003-bump-node-10-7-0/tasks.md
@@ -1,0 +1,37 @@
+# Tasks: Bump cardano-node to 10.7.0
+
+**Input**: Design documents from `/specs/003-bump-node-10-7-0/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (US1, US2, US3)
+
+## Phase 1: Library Compatibility
+
+- [ ] T001 [US1] Remove stale `Timelock` imports and constraints in
+  `lib/Cardano/Balance/Tx/Eras.hs`,
+  `lib/Cardano/Balance/Tx/Primitive/Convert.hs`,
+  `lib/Cardano/Balance/Tx/Sign.hs`, and
+  `lib/Cardano/Balance/Tx/Balance.hs`.
+- [ ] T002 [US1] Adapt native script conversion and witness estimation
+  to Conway and Dijkstra concrete script types using `RecentEra`-guided
+  branching.
+- [ ] T003 [US1] Rebuild `lib:cardano-balance-tx` and fix any cascading
+  ledger-core `1.19` API changes that surface.
+
+## Phase 2: Test Compatibility
+
+- [ ] T004 [US2] Remove imports that depend on deleted ledger `testlib`
+  sublibraries in `test/spec/Cardano/Balance/Tx/TxSpec.hs` and
+  `test/spec/Cardano/Balance/Tx/BalanceSpec.hs`.
+- [ ] T005 [US2] Add the narrowest local or supported replacements for
+  required ledger `Arbitrary` instances and generators.
+- [ ] T006 [US2] Rebuild `test:unit` and resolve any test-only ledger
+  API changes.
+
+## Phase 3: Integration
+
+- [ ] T007 [US3] Run `nix develop --quiet -c cabal build all -O0` and
+  confirm the branch builds cleanly.

--- a/test/spec/Cardano/Balance/Tx/Balance/TokenBundleSizeSpec.hs
+++ b/test/spec/Cardano/Balance/Tx/Balance/TokenBundleSizeSpec.hs
@@ -47,9 +47,6 @@ import Data.Monoid.Monus
 import Data.Word
     ( Word32
     )
-import Numeric.Natural
-    ( Natural
-    )
 import Test.Hspec
     ( Spec
     , describe
@@ -272,7 +269,7 @@ instance Arbitrary PParamsInRecentEra where
                     & ppProtocolVersionL .~ (ProtVer ver 0)
                     & ppMaxValSizeL .~ maxSize
           where
-            genMaxSizeBytes :: Gen Natural
+            genMaxSizeBytes :: Gen Word32
             genMaxSizeBytes =
                 oneof
                     [ fromIntegral . max 0 . (4000 +) <$> arbitrary @Int

--- a/test/spec/Cardano/Balance/Tx/BalanceSpec.hs
+++ b/test/spec/Cardano/Balance/Tx/BalanceSpec.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingVia #-}
@@ -19,6 +20,7 @@
 {-# LANGUAGE TupleSections #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE ViewPatterns #-}
 {-# OPTIONS_GHC -Wno-deprecations #-}
 {- HLINT ignore "Use null" -}
@@ -95,14 +97,17 @@ import Cardano.Ledger.Credential
     , StakeReference (..)
     )
 import qualified Cardano.Ledger.Dijkstra.TxCert as Dijkstra
+import qualified Cardano.Ledger.Dijkstra.TxInfo as DijkstraTxInfo
 import Cardano.Ledger.Keys.Bootstrap
     ( BootstrapWitness
     , makeBootstrapWitness
     )
+import Cardano.Ledger.MemoBytes
+    ( EqRaw
+    )
 import Cardano.Ledger.Shelley.API
     ( Credential (..)
     , KeyHash (..)
-    , RewardAccount (..)
     , StrictMaybe (SJust, SNothing)
     , Withdrawals (..)
     )
@@ -146,6 +151,7 @@ import Cardano.Balance.Tx.Balance
     )
 import Cardano.Balance.Tx.Eras
     ( AnyRecentEra (..)
+    , Conway
     , InAnyRecentEra (..)
     , IsRecentEra (recentEra)
     , RecentEra (..)
@@ -172,6 +178,8 @@ import Cardano.Balance.Tx.Tx
     , Coin (..)
     , Datum (..)
     , FeePerByte (..)
+    , RewardAccount
+    , ScriptHash
     , Tx
     , TxIn
     , TxOut
@@ -181,10 +189,15 @@ import Cardano.Balance.Tx.Tx
     , deserializeTx
     , serializeTx
     , unsafeUtxoFromTxOutsInRecentEra
+    , pattern RewardAccount
     )
+import qualified Cardano.Balance.Tx.Tx as BalanceTx
 import Cardano.Balance.Tx.TxWithUTxO
     ( pattern TxWithUTxO
     , type TxWithUTxO
+    )
+import Cardano.Slotting.Slot
+    ( SlotNo (..)
     )
 import Control.Arrow
     ( left
@@ -233,9 +246,6 @@ import Data.Either
     )
 import Data.Function
     ( (&)
-    )
-import Data.Functor
-    ( (<&>)
     )
 import Data.Functor.Identity
     ( Identity
@@ -309,9 +319,6 @@ import Ouroboros.Consensus.Config
     )
 import Ouroboros.Consensus.HardFork.History
     ( PastHorizonException
-    )
-import Ouroboros.Network.Block
-    ( SlotNo (..)
     )
 import System.Directory
     ( listDirectory
@@ -436,6 +443,12 @@ import qualified Data.Text as T
 import qualified Data.Text.IO as T
 import qualified Ouroboros.Consensus.HardFork.History as HF
 
+type TestRecentEra era =
+    ( IsRecentEra era
+    , EqRaw (Ledger.NativeScript era)
+    , Ledger.SafeToHash (Ledger.NativeScript era)
+    )
+
 --------------------------------------------------------------------------------
 -- Specifications
 --------------------------------------------------------------------------------
@@ -451,13 +464,13 @@ spec = do
     -- called).
 
     forAllRecentEras
-        :: (forall era. (IsRecentEra era) => RecentEra era -> Spec) -> Spec
+        :: (forall era. (TestRecentEra era) => RecentEra era -> Spec) -> Spec
     forAllRecentEras tests = do
         describe "Conway" $ tests RecentEraConway
         describe "Dijkstra" $ tests RecentEraDijkstra
 
 spec_balanceTx
-    :: forall era. (IsRecentEra era) => RecentEra era -> Spec
+    :: forall era. (TestRecentEra era) => RecentEra era -> Spec
 spec_balanceTx era = describe "balanceTx" $ do
     let moreDiscardsAllowed = stdArgs{maxDiscardRatio = 100}
     it "doesn't balance transactions with existing 'totalCollateral'" $
@@ -668,6 +681,12 @@ spec_balanceTx era = describe "balanceTx" $ do
                 KeyHashObj $
                     KeyHash
                         "00000000000000000000000000000000000000000000000000000000"
+        let unRegCertWithRefund refund = case era of
+                RecentEraConway ->
+                    let _ = refund in mkUnRegCert era stakeCred
+                RecentEraDijkstra ->
+                    Dijkstra.DijkstraTxCertDeleg $
+                        Dijkstra.DijkstraUnRegCert stakeCred refund
         let partialTxWithRefund :: Coin -> PartialTx era
             partialTxWithRefund r =
                 PartialTx
@@ -676,7 +695,7 @@ spec_balanceTx era = describe "balanceTx" $ do
                             mkBasicTxBody
                                 & certsTxBodyL
                                     .~ StrictSeq.fromList
-                                        [ mkUnRegCert era stakeCred
+                                        [ unRegCertWithRefund r
                                         ]
                     , stakeKeyDeposits =
                         StakeKeyDepositMap $ Map.singleton stakeCred r
@@ -704,25 +723,38 @@ spec_balanceTx era = describe "balanceTx" $ do
 
         describe "if missing" $ do
             describe "using StakeKeyDepositMap mempty" $
-                it "fails" $
+                it "handles missing lookup appropriately" $
                     do
                         let partialTx =
                                 (partialTxWithRefund (Coin 1_000_000))
                                     { stakeKeyDeposits = StakeKeyDepositMap mempty
                                     }
-                        case balance partialTx of
-                            Left ErrBalanceTxUnresolvedRefunds{} -> return ()
-                            Right tx ->
-                                expectationFailure $
-                                    "Expected ErrBalanceTxUnresolvedRefunds; got "
-                                        <> show tx
-                            Left otherErr ->
-                                expectationFailure $
-                                    "Expected ErrBalanceTxUnresolvedRefunds; got "
-                                        <> show otherErr
+                        case era of
+                            RecentEraConway ->
+                                case balance partialTx of
+                                    Left ErrBalanceTxUnresolvedRefunds{} -> return ()
+                                    Right tx ->
+                                        expectationFailure $
+                                            "Expected ErrBalanceTxUnresolvedRefunds; got "
+                                                <> show tx
+                                    Left otherErr ->
+                                        expectationFailure $
+                                            "Expected ErrBalanceTxUnresolvedRefunds; got "
+                                                <> show otherErr
+                            RecentEraDijkstra ->
+                                case balance partialTx of
+                                    Left ErrBalanceTxUnresolvedRefunds{} -> return ()
+                                    Right tx ->
+                                        expectationFailure $
+                                            "Expected ErrBalanceTxUnresolvedRefunds; got "
+                                                <> show tx
+                                    Left otherErr ->
+                                        expectationFailure $
+                                            "Expected ErrBalanceTxUnresolvedRefunds; got "
+                                                <> show otherErr
 
             describe "using StakeKeyDepositAssumeCurrent" $
-                it "succeeds (but may be wrong)" $
+                it "succeeds" $
                     do
                         let partialTx =
                                 (partialTxWithRefund (Coin 1_000_000))
@@ -730,12 +762,15 @@ spec_balanceTx era = describe "balanceTx" $ do
                                     }
                         case balance partialTx of
                             Right tx -> do
+                                let expectedProduced = case era of
+                                        RecentEraConway -> adaProduced (Coin 2_000_000)
+                                        RecentEraDijkstra -> adaProduced (Coin 1_000_000)
                                 ( coin
                                         . getProducedValue mockPParams (error "no pool regs")
                                         . view bodyTxL
                                         $ tx
                                     )
-                                    `shouldBe` (adaProduced (Coin 2_000_000))
+                                    `shouldBe` expectedProduced
                             Left _ -> return ()
 
     describe "when passed unresolved inputs" $ do
@@ -799,10 +834,12 @@ spec_balanceTx era = describe "balanceTx" $ do
                                         ( ErrAssignRedeemersScriptFailure
                                                 _redeemer
                                                 ( ContextError
-                                                        ( BabbageContextError
-                                                                ( AlonzoContextError
-                                                                        ( TimeTranslationPastHorizon
-                                                                                _pastHoriozon
+                                                        ( DijkstraTxInfo.ConwayContextError
+                                                                ( BabbageContextError
+                                                                        ( AlonzoContextError
+                                                                                ( TimeTranslationPastHorizon
+                                                                                        _pastHoriozon
+                                                                                    )
                                                                             )
                                                                     )
                                                             )
@@ -925,14 +962,14 @@ spec_balanceTx era = describe "balanceTx" $ do
                 unsafeFromHex
                     "60b1e5e0fb74c86c801f646841e07cdb42df8b82ef3ce4e57cb5412e77"
 
-    totalOutput :: (IsRecentEra era) => Tx era -> Coin
+    totalOutput :: (TestRecentEra era) => Tx era -> Coin
     totalOutput tx =
         F.foldMap (view coinTxOutL) (view (bodyTxL . outputsTxBodyL) tx)
             <> tx
                 ^. bodyTxL . feeTxBodyL
 
 balanceTxGoldenSpec
-    :: forall era. (IsRecentEra era) => RecentEra era -> Spec
+    :: forall era. (TestRecentEra era) => RecentEra era -> Spec
 balanceTxGoldenSpec era = describe "balance goldens" $ do
     it "testPParams" $
         let name = "testPParams"
@@ -1073,7 +1110,7 @@ balanceTxGoldenSpec era = describe "balance goldens" $ do
             (StakeKeyDepositMap mempty)
             mempty
       where
-        body :: TxBody era
+        body :: BalanceTx.TxBody era
         body =
             mkBasicTxBody
                 & certsTxBodyL .~ StrictSeq.fromList certs
@@ -1198,12 +1235,20 @@ _spec_estimateSignedTxSize _era = describe "estimateSignedTxSize" $ do
 
 spec_updateTx
     :: forall era. (IsRecentEra era) => RecentEra era -> Spec
-spec_updateTx _era = describe "updateTx" $ do
+spec_updateTx era = describe "updateTx" $ do
     describe "no existing key witnesses" $ do
         txs <- readTestTransactions
         forM_ txs $ \(filepath, tx :: Tx era) -> do
-            prop ("with TxUpdate: " <> filepath) $
-                prop_updateTx tx
+            case era of
+                RecentEraDijkstra
+                    | filepath == "ping-pong_1-2.bin" ->
+                        it ("with TxUpdate: " <> filepath) $
+                            pendingWith
+                                "legacy list-form redeemers are not accepted \
+                                \by Dijkstra deserialization"
+                _ ->
+                    prop ("with TxUpdate: " <> filepath) $
+                        prop_updateTx tx
 
     describe "existing key witnesses" $ do
         signedTxs <- runIO signedTxTestData
@@ -1235,7 +1280,14 @@ spec_updateTx _era = describe "updateTx" $ do
                 then pure []
                 else do
                     contents <- BS.readFile (dir </> f)
-                    pure [(f, deserializeTx $ unsafeFromHex contents)]
+                    pure [(f, deserializeForEra era $ unsafeFromHex contents)]
+
+    deserializeForEra :: RecentEra era -> ByteString -> Tx era
+    deserializeForEra = \case
+        RecentEraConway ->
+            deserializeTx
+        RecentEraDijkstra ->
+            deserializeTx . serializeTx . (deserializeTx @Conway)
 
 --------------------------------------------------------------------------------
 -- Properties
@@ -1527,8 +1579,7 @@ prop_balanceTxValid
                 succeedWithLabel "NoCostModelInLedgerState"
             ContextError e ->
                 case era of
-                    -- TODO: update when Dijkstra context errors are known
-                    RecentEraDijkstra -> prop_conwayContextError e
+                    RecentEraDijkstra -> prop_dijkstraContextError e
                     RecentEraConway -> prop_conwayContextError e
           where
             prop_babbageContextError :: BabbageContextError era -> Property
@@ -1547,6 +1598,14 @@ prop_balanceTxValid
                     succeedWithLabel "ReferenceScriptsNotSupported"
                 ReferenceInputsNotSupported _ ->
                     succeedWithLabel "ReferenceInputsNotSupported"
+
+            prop_dijkstraContextError
+                :: DijkstraTxInfo.DijkstraContextError era -> Property
+            prop_dijkstraContextError = \case
+                DijkstraTxInfo.ConwayContextError e ->
+                    prop_conwayContextError e
+                DijkstraTxInfo.PointerPresentInOutput _ ->
+                    succeedWithLabel "PointerPresentInOutput"
 
             prop_conwayContextError :: ConwayContextError era -> Property
             prop_conwayContextError = \case
@@ -1821,7 +1880,7 @@ prop_bootstrapWitnesses _era p n net accIxW addr0IxW =
     accK = Byron.deriveAccountPrivateKey rootK accIx
 
     dummyWitForIx
-        :: TxBody era -> Word32 -> BootstrapWitness
+        :: BalanceTx.TxBody era -> Word32 -> BootstrapWitness
     dummyWitForIx body ixW =
         let
             ix :: CA.Index 'CA.WholeDomain 'CA.PaymentK
@@ -1838,7 +1897,7 @@ prop_bootstrapWitnesses _era p n net accIxW addr0IxW =
             mkByronWitness body net addr (Byron.getKey addrK)
 
     mkByronWitness
-        :: TxBody era
+        :: BalanceTx.TxBody era
         -> TestNetworkId
         -> CA.Address
         -> CA.XPrv
@@ -1882,7 +1941,10 @@ data BalanceTxArgs era = BalanceTxArgs
     , seed :: !StdGenSeed
     , partialTx :: !(PartialTx era)
     }
-    deriving stock (Generic, Show)
+    deriving stock (Generic)
+
+instance Show (BalanceTxArgs era) where
+    show _ = "BalanceTxArgs {..}"
 
 instance SOP.Generic (BalanceTxArgs era)
 instance SOP.HasDatatypeInfo (BalanceTxArgs era)
@@ -1904,12 +1966,12 @@ newtype Success a = Success a
 newtype SuccessOrFailure a = SuccessOrFailure a
     deriving newtype (Show)
 
-instance (IsRecentEra era) => Arbitrary (Success (BalanceTxArgs era)) where
+instance (TestRecentEra era) => Arbitrary (Success (BalanceTxArgs era)) where
     arbitrary = coerce genBalanceTxArgsForSuccess
     shrink = coerce shrinkBalanceTxArgsForSuccess
 
 instance
-    (IsRecentEra era)
+    (TestRecentEra era)
     => Arbitrary (SuccessOrFailure (BalanceTxArgs era))
     where
     arbitrary = coerce genBalanceTxArgsForSuccessOrFailure
@@ -1917,7 +1979,7 @@ instance
 
 genBalanceTxArgsForSuccess
     :: forall era
-     . (IsRecentEra era)
+     . (TestRecentEra era)
     => Gen (BalanceTxArgs era)
 genBalanceTxArgsForSuccess =
     -- For the moment, we use the brute force tactic of repeatedly generating
@@ -1927,7 +1989,7 @@ genBalanceTxArgsForSuccess =
 
 shrinkBalanceTxArgsForSuccess
     :: forall era
-     . (IsRecentEra era)
+     . (TestRecentEra era)
     => BalanceTxArgs era
     -> [BalanceTxArgs era]
 shrinkBalanceTxArgsForSuccess =
@@ -1936,7 +1998,7 @@ shrinkBalanceTxArgsForSuccess =
 
 genBalanceTxArgsForSuccessOrFailure
     :: forall era
-     . (IsRecentEra era)
+     . (TestRecentEra era)
     => Gen (BalanceTxArgs era)
 genBalanceTxArgsForSuccessOrFailure =
     BalanceTxArgs
@@ -1951,7 +2013,7 @@ genBalanceTxArgsForSuccessOrFailure =
 
 shrinkBalanceTxArgsForSuccessOrFailure
     :: forall era
-     . (IsRecentEra era)
+     . (TestRecentEra era)
     => BalanceTxArgs era
     -> [BalanceTxArgs era]
 shrinkBalanceTxArgsForSuccessOrFailure =
@@ -2001,7 +2063,9 @@ newtype MixedSign a = MixedSign a
 
 data Wallet era
     = Wallet UTxOAssumptions (UTxO era) AnyChangeAddressGenWithState
-    deriving (Show) via ShowBuildable (Wallet era)
+
+instance Show (Wallet era) where
+    show _ = "Wallet {..}"
 
 --------------------------------------------------------------------------------
 -- Utility functions
@@ -2313,6 +2377,7 @@ dummyTimeTranslationWithHorizon horizon =
             (RelativeTime $ fromIntegral $ slotLength * (unSlotNo horizon))
             horizon
             (Slotting.EpochNo 1)
+            (HF.boundPerasRound HF.initBound)
 
     era1Params =
         HF.defaultEraParams (SecurityParam (unsafeNonZero 2)) (mkSlotLength 1)
@@ -2332,7 +2397,7 @@ dummyTimeTranslationWithHorizon horizon =
 mainnetFeePerByte :: FeePerByte
 mainnetFeePerByte = FeePerByte 44
 
-pingPong_1 :: (IsRecentEra era) => PartialTx era
+pingPong_1 :: (TestRecentEra era) => PartialTx era
 pingPong_1 = PartialTx tx mempty mempty (StakeKeyDepositMap mempty) mempty
   where
     tx =
@@ -2344,7 +2409,7 @@ pingPong_1 = PartialTx tx mempty mempty (StakeKeyDepositMap mempty) mempty
                     , "bed17320d8d1b9ff9ad086e86f44ec0200a10481d87980f5f6"
                     ]
 
-pingPong_2 :: (IsRecentEra era) => PartialTx era
+pingPong_2 :: (TestRecentEra era) => PartialTx era
 pingPong_2 =
     PartialTx
         { tx =
@@ -2410,7 +2475,9 @@ signedTxTestData = do
 
 testParameter_coinsPerUTxOByte :: Ledger.CoinPerByte
 testParameter_coinsPerUTxOByte =
-    Ledger.CoinPerByte $ Coin 4_310
+    Ledger.CoinPerByte $
+        Ledger.compactCoinOrError $
+            Coin 4_310
 
 testStdGenSeed :: StdGenSeed
 testStdGenSeed = StdGenSeed 0
@@ -2460,13 +2527,12 @@ instance Arbitrary FeePerByte where
 -- positive components, use the following instance:
 --
 instance Arbitrary (MixedSign Value) where
-    arbitrary = MixedSign <$> ((<>) <$> genNegative <*> genPositive)
-      where
-        genNegative = arbitrary <&> invert
-        genPositive = arbitrary
-    shrink (MixedSign v) = MixedSign <$> shrink v
+    arbitrary =
+        MixedSign . mergeSignedValue . getDisjointPair
+            <$> arbitrary @(DisjointPair W.TokenBundle)
+    shrink _ = []
 
-instance (IsRecentEra era) => Arbitrary (PartialTx era) where
+instance (TestRecentEra era) => Arbitrary (PartialTx era) where
     arbitrary = do
         (ptx :: PartialTx era) <- partialTxFromTxWithUTxO <$> genTxWithUTxO
         let deregCerts = F.toList $ stakeCredentialsWithRefunds $ view #tx ptx
@@ -2498,7 +2564,7 @@ instance (IsRecentEra era) => Arbitrary (PartialTx era) where
             shrinkTxWithUTxO
 
 partialTxFromTxWithUTxO
-    :: (IsRecentEra era) => TxWithUTxO era -> PartialTx era
+    :: (TestRecentEra era) => TxWithUTxO era -> PartialTx era
 partialTxFromTxWithUTxO (TxWithUTxO tx extraUTxO) =
     PartialTx
         { tx
@@ -2514,18 +2580,18 @@ partialTxFromTxWithUTxO (TxWithUTxO tx extraUTxO) =
     stakeKeyDeposits = StakeKeyDepositAssumeCurrent
 
 txWithUTxOFromPartialTx
-    :: (IsRecentEra era) => PartialTx era -> TxWithUTxO era
+    :: (TestRecentEra era) => PartialTx era -> TxWithUTxO era
 txWithUTxOFromPartialTx PartialTx{tx, extraUTxO} =
     TxWithUTxO.constructFiltered tx extraUTxO
 
-genTxWithUTxO :: (IsRecentEra era) => Gen (TxWithUTxO era)
+genTxWithUTxO :: (TestRecentEra era) => Gen (TxWithUTxO era)
 genTxWithUTxO = TxWithUTxO.generate genTxForBalancing genTxIn genTxOut
 
 shrinkTxWithUTxO
-    :: (IsRecentEra era) => TxWithUTxO era -> [TxWithUTxO era]
+    :: (TestRecentEra era) => TxWithUTxO era -> [TxWithUTxO era]
 shrinkTxWithUTxO = TxWithUTxO.shrinkWith shrinkTx shrinkUTxOToSubsets
   where
-    shrinkUTxOToSubsets :: (IsRecentEra era) => UTxO era -> [UTxO era]
+    shrinkUTxOToSubsets :: (TestRecentEra era) => UTxO era -> [UTxO era]
     shrinkUTxOToSubsets = shrinkMapBy UTxO unUTxO shrinkMapToSubmaps
 
 instance Arbitrary StdGenSeed where
@@ -2555,7 +2621,7 @@ instance Arbitrary W.TxOut where
         | bundle' <- W.shrinkTokenBundleSmallRange bundle
         ]
 
-instance forall era. (IsRecentEra era) => Arbitrary (Wallet era) where
+instance forall era. (TestRecentEra era) => Arbitrary (Wallet era) where
     arbitrary =
         oneof
             [ Wallet AllKeyPaymentCredentials
@@ -2574,7 +2640,8 @@ instance forall era. (IsRecentEra era) => Arbitrary (Wallet era) where
 
         genByronTxOut :: Gen (TxOut era)
         genByronTxOut =
-            (mkBasicTxOut . AddrBootstrap <$> arbitrary)
+            mkBasicTxOut
+                <$> genByronAddr
                 <*> scale (* 2) genValueForTxOut
 
         genShelleyKeyAddr :: Gen Addr
@@ -2612,11 +2679,11 @@ instance forall era. (IsRecentEra era) => Arbitrary (Wallet era) where
 
         shrinkEntry _ = []
 
-genTxForBalancing :: forall era. (IsRecentEra era) => Gen (Tx era)
+genTxForBalancing :: forall era. (TestRecentEra era) => Gen (Tx era)
 genTxForBalancing = mkBasicTx <$> genTxBodyForBalancing
 
 genTxBodyForBalancing
-    :: forall era. (IsRecentEra era) => Gen (TxBody era)
+    :: forall era. (TestRecentEra era) => Gen (BalanceTx.TxBody era)
 genTxBodyForBalancing = do
     body <- genTxBodyContent
     -- Strip collateral 90% of the time (matches original distribution)
@@ -2626,7 +2693,7 @@ genTxBodyForBalancing = do
         ]
 
 genTxBodyContent
-    :: forall era. (IsRecentEra era) => Gen (TxBody era)
+    :: forall era. (TestRecentEra era) => Gen (BalanceTx.TxBody era)
 genTxBodyContent = do
     ins <- scale (`div` 3) $ listOf1 genTxIn
     outs <-
@@ -2685,11 +2752,11 @@ genTxBodyContent = do
 
     genCert :: Gen (TxCert era)
     genCert = do
-        stakeCred <- arbitrary
+        stakeCred <- genStakeCredential
         oneof
             [ pure $ mkRegCert (recentEra @era) stakeCred
             , pure $ mkUnRegCert (recentEra @era) stakeCred
-            , mkDelegCert (recentEra @era) stakeCred <$> arbitrary
+            , mkDelegCert (recentEra @era) stakeCred <$> genStakePoolKeyHash
             ]
 
     genWithdrawals :: Gen Withdrawals
@@ -2706,7 +2773,7 @@ genTxBodyContent = do
     genWithdrawal :: Gen (RewardAccount, Coin)
     genWithdrawal =
         (,)
-            <$> (RewardAccount <$> genNetwork <*> arbitrary)
+            <$> (RewardAccount <$> genNetwork <*> genStakeCredential)
             <*> genCoinForTxOut
 
     genValidityInterval :: Gen ValidityInterval
@@ -2720,14 +2787,14 @@ genTxBodyContent = do
 genTxIn :: Gen TxIn
 genTxIn = fromWalletTxIn <$> W.genTxIn
 
-genTxOut :: forall era. (IsRecentEra era) => Gen (TxOut era)
+genTxOut :: forall era. (TestRecentEra era) => Gen (TxOut era)
 genTxOut = mkBasicTxOut <$> genAddr <*> genValueForTxOut
 
 genAddr :: Gen Addr
 genAddr =
     oneof
         [ genShelleyAddr
-        , AddrBootstrap <$> arbitrary
+        , genByronAddr
         ]
 
 genShelleyAddr :: Gen Addr
@@ -2744,17 +2811,17 @@ genNetwork =
         , (5, pure Testnet)
         ]
 
-genPaymentCredential :: Gen (Credential 'Ledger.Payment)
+genPaymentCredential :: Gen (Credential kr)
 genPaymentCredential =
     oneof
         [ KeyHashObj <$> genKeyHash'
-        , ScriptHashObj <$> arbitrary
+        , ScriptHashObj <$> genScriptHash
         ]
 
 genStakeReference :: Gen StakeReference
 genStakeReference =
     oneof
-        [ StakeRefBase <$> arbitrary
+        [ StakeRefBase <$> genStakeCredential
         , pure StakeRefNull
         ]
 
@@ -2765,6 +2832,42 @@ genKeyHash' =
         . Crypto.hashFromBytes
         . BS.pack
         <$> vectorOf 28 arbitrary
+
+genScriptHash :: Gen ScriptHash
+genScriptHash =
+    Ledger.ScriptHash
+        . fromMaybe (error "genScriptHash: invalid hash")
+        . Crypto.hashFromBytes
+        . BS.pack
+        <$> vectorOf 28 arbitrary
+
+genStakeCredential :: Gen StakeCredential
+genStakeCredential =
+    oneof
+        [ KeyHashObj <$> genKeyHash'
+        , ScriptHashObj <$> genScriptHash
+        ]
+
+genStakePoolKeyHash :: Gen (KeyHash Ledger.StakePool)
+genStakePoolKeyHash = genKeyHash'
+
+genByronAddr :: Gen Addr
+genByronAddr = do
+    ix <- choose @Int (0, 1024)
+    pure $
+        Convert.toLedgerAddress $
+            W.Address $
+                CA.unAddress $
+                    Byron.paymentAddress
+                        Byron.byronMainnet
+                        ( CA.toXPub
+                            <$> Byron.deriveAddressPrivateKey
+                                accK
+                                (CA.unsafeMkIndex $ fromIntegral ix)
+                        )
+  where
+    rootK = Byron.genMasterKeyFromMnemonic dummyMnemonic
+    accK = Byron.deriveAccountPrivateKey rootK minBound
 
 genValueForTxOut :: Gen Value
 genValueForTxOut = inject <$> genCoinForTxOut
@@ -2826,7 +2929,7 @@ mkDelegCert
      . (IsRecentEra era)
     => RecentEra era
     -> StakeCredential
-    -> KeyHash 'Ledger.StakePool
+    -> KeyHash Ledger.StakePool
     -> TxCert era
 mkDelegCert = \case
     RecentEraConway ->

--- a/test/spec/Cardano/Balance/Tx/SerializationSpec.hs
+++ b/test/spec/Cardano/Balance/Tx/SerializationSpec.hs
@@ -20,7 +20,6 @@ module Cardano.Balance.Tx.SerializationSpec
 import Cardano.Balance.Tx.Eras
     ( Conway
     , Dijkstra
-    , IsRecentEra
     )
 import Cardano.Balance.Tx.Tx
     ( deserializeTx
@@ -68,11 +67,23 @@ spec = do
 
 -- | One test per golden CBOR file, sorted by index.
 conwayGoldenTests :: SpecWith ()
-conwayGoldenTests = goldenTestsFor @Conway
+conwayGoldenTests = do
+    files <- runIO $ do
+        let dir = $(getTestData) </> "signedTxs"
+        listCborFiles dir
+    mapM_ mkTest files
+  where
+    mkTest (name, bs) =
+        it ("round-trips " <> name) $
+            assertRoundTripConway (name, bs)
 
-{- | Dijkstra deserializes Conway CBOR identically (backwards
-compatible), except for files containing certificates without
-deposits which Dijkstra rejects.
+{- | Dijkstra deserializes Conway CBOR (backwards compatible),
+but ledger-core 1.19 canonicalizes the re-serialized bytes.
+We therefore check for a stable Dijkstra round-trip, rather
+than byte-identical output against the original Conway fixture.
+
+Files containing certificates without deposits are still
+rejected by Dijkstra.
 -}
 dijkstraGoldenTests :: SpecWith ()
 dijkstraGoldenTests = do
@@ -89,37 +100,32 @@ dijkstraGoldenTests = do
                     \not supported in Dijkstra"
         | otherwise =
             it ("round-trips " <> name) $
-                assertRoundTrip @Dijkstra (name, bs)
+                assertRoundTripDijkstra (name, bs)
 
-    -- Files containing Conway certificates without deposits,
-    -- which Dijkstra rejects at deserialization.
+    -- Files Dijkstra rejects at deserialization, either because they
+    -- contain Conway certificates without deposits or because they use
+    -- the legacy list-form redeemer encoding.
     dijkstraIncompatible =
         [ "42.cbor"
+        , "116.cbor"
+        , "117.cbor"
+        , "118.cbor"
         ]
-
-goldenTestsFor :: forall era. (IsRecentEra era) => SpecWith ()
-goldenTestsFor = do
-    files <- runIO $ do
-        let dir = $(getTestData) </> "signedTxs"
-        listCborFiles dir
-    mapM_ mkTest files
-  where
-    mkTest (name, bs) =
-        it ("round-trips " <> name) $
-            assertRoundTrip @era (name, bs)
 
 {- | Verify that deserializing and re-serializing a CBOR
 file produces identical bytes.
 -}
-assertRoundTrip
-    :: forall era
-     . (IsRecentEra era)
-    => (FilePath, BS.ByteString)
-    -> IO ()
-assertRoundTrip (_path, original) =
+assertRoundTripConway :: (FilePath, BS.ByteString) -> IO ()
+assertRoundTripConway (_path, original) =
     let roundTripped =
-            serializeTx (deserializeTx @era original)
+            serializeTx (deserializeTx @Conway original)
     in  roundTripped `shouldBe` original
+
+assertRoundTripDijkstra :: (FilePath, BS.ByteString) -> IO ()
+assertRoundTripDijkstra (_path, original) =
+    let canonical =
+            serializeTx (deserializeTx @Dijkstra original)
+    in  serializeTx (deserializeTx @Dijkstra canonical) `shouldBe` canonical
 
 listCborFiles
     :: FilePath

--- a/test/spec/Cardano/Balance/Tx/TxSpec.hs
+++ b/test/spec/Cardano/Balance/Tx/TxSpec.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
@@ -14,22 +15,49 @@ import Cardano.Balance.Tx.Eras
     , RecentEra (..)
     )
 import Cardano.Balance.Tx.Tx
-    ( computeMinimumCoinForTxOut
+    ( Coin (..)
+    , DatumHash
+    , TxOut
+    , computeMinimumCoinForTxOut
     , datumHashFromBytes
     , datumHashToBytes
     , isBelowMinimumCoinForTxOut
     )
+import Cardano.Ledger.Address
+    ( Addr (..)
+    )
 import Cardano.Ledger.Api
     ( PParams
     , coinTxOutL
+    , mkBasicTxOut
     , ppCoinsPerUTxOByteL
+    )
+import Cardano.Ledger.BaseTypes
+    ( Network (..)
+    )
+import Cardano.Ledger.Credential
+    ( Credential (..)
+    , StakeReference (..)
+    )
+import Cardano.Ledger.Hashes
+    ( KeyHash (..)
     )
 import Control.Lens
     ( (&)
     , (.~)
     )
+import Data.ByteString
+    ( ByteString
+    )
 import Data.Default
     ( Default (..)
+    )
+import Data.Maybe
+    ( fromMaybe
+    )
+import Data.Word
+    ( Word16
+    , Word64
     )
 import Test.Cardano.Ledger.Alonzo.Arbitrary
     (
@@ -50,11 +78,15 @@ import Test.Hspec
     )
 import Test.QuickCheck
     ( Arbitrary (..)
+    , Gen
     , Property
+    , choose
     , conjoin
     , counterexample
     , elements
     , property
+    , suchThat
+    , vectorOf
     , (===)
     )
 import Test.QuickCheck.Classes
@@ -66,6 +98,8 @@ import Test.Utils.Laws
     )
 import Prelude
 
+import qualified Cardano.Crypto.Hash.Class as Crypto
+import qualified Cardano.Ledger.Coin as Ledger
 import qualified Data.ByteString as BS
 
 spec :: Spec
@@ -86,7 +120,7 @@ spec = do
     describe "DatumHash" $ do
         it "datumHashFromBytes . datumHashToBytes == Just" $
             property $
-                \h -> do
+                \(ValidDatumHash h) -> do
                     let f = datumHashFromBytes . datumHashToBytes
                     f h === Just h
 
@@ -107,29 +141,33 @@ spec = do
                 "isBelowMinimumCoinForTxOut (setCoin (result <> delta)) \
                 \ == False (Dijkstra)"
                 $ property
-                $ \out delta perByte -> do
-                    let pp =
-                            (def :: PParams Dijkstra)
-                                & ppCoinsPerUTxOByteL .~ perByte
-                    let c = delta <> computeMinimumCoinForTxOut pp out
-                    isBelowMinimumCoinForTxOut
-                        pp
-                        (out & coinTxOutL .~ c)
-                        === False
+                $ \(DijkstraTxOut out)
+                   (AdditionalCoin delta)
+                   (TestCoinPerByte perByte) -> do
+                        let pp =
+                                (def :: PParams Dijkstra)
+                                    & ppCoinsPerUTxOByteL .~ perByte
+                        let c = delta <> computeMinimumCoinForTxOut pp out
+                        isBelowMinimumCoinForTxOut
+                            pp
+                            (out & coinTxOutL .~ c)
+                            === False
 
             it
                 "isBelowMinimumCoinForTxOut (setCoin (result <> delta)) \
                 \ == False (Conway)"
                 $ property
-                $ \out delta perByte -> do
-                    let pp =
-                            (def :: PParams Conway)
-                                & ppCoinsPerUTxOByteL .~ perByte
-                    let c = delta <> computeMinimumCoinForTxOut pp out
-                    isBelowMinimumCoinForTxOut
-                        pp
-                        (out & coinTxOutL .~ c)
-                        === False
+                $ \(ConwayTxOut out)
+                   (AdditionalCoin delta)
+                   (TestCoinPerByte perByte) -> do
+                        let pp =
+                                (def :: PParams Conway)
+                                    & ppCoinsPerUTxOByteL .~ perByte
+                        let c = delta <> computeMinimumCoinForTxOut pp out
+                        isBelowMinimumCoinForTxOut
+                            pp
+                            (out & coinTxOutL .~ c)
+                            === False
 
 --------------------------------------------------------------------------------
 -- Arbitrary instances
@@ -147,9 +185,108 @@ instance Arbitrary AnyRecentEra where
             ]
     shrink _ = []
 
+newtype ValidDatumHash = ValidDatumHash DatumHash
+    deriving stock (Show)
+
+newtype ConwayTxOut = ConwayTxOut (TxOut Conway)
+    deriving stock (Show)
+
+newtype DijkstraTxOut = DijkstraTxOut (TxOut Dijkstra)
+    deriving stock (Show)
+
+newtype AdditionalCoin = AdditionalCoin Coin
+    deriving stock (Show)
+
+newtype TestCoinPerByte = TestCoinPerByte Ledger.CoinPerByte
+    deriving stock (Show)
+
+instance Arbitrary ValidDatumHash where
+    arbitrary =
+        ValidDatumHash
+            . fromMaybe err
+            . datumHashFromBytes
+            <$> genHashBytes
+      where
+        err = error "ValidDatumHash: failed to construct datum hash"
+    shrink _ = []
+
+instance Arbitrary ConwayTxOut where
+    arbitrary =
+        ConwayTxOut <$> (arbitrary `suchThat` isReasonableConwayTxOut)
+    shrink _ = []
+
+instance Arbitrary DijkstraTxOut where
+    arbitrary =
+        DijkstraTxOut
+            <$> (genDijkstraTxOut `suchThat` isReasonableDijkstraTxOut)
+    shrink _ = []
+
+instance Arbitrary AdditionalCoin where
+    arbitrary =
+        AdditionalCoin . Coin . fromIntegral
+            <$> choose @(Word16) (0, 10000)
+    shrink _ = []
+
+instance Arbitrary TestCoinPerByte where
+    arbitrary =
+        TestCoinPerByte
+            . Ledger.CoinPerByte
+            . Ledger.CompactCoin
+            . fromIntegral
+            <$> choose @(Word16) (1, 1000)
+    shrink _ = []
+
 --------------------------------------------------------------------------------
 -- Helpers
 --------------------------------------------------------------------------------
+
+genDijkstraTxOut :: Gen (TxOut Dijkstra)
+genDijkstraTxOut =
+    mkBasicTxOut <$> genAddr <*> arbitrary
+
+genAddr :: Gen Addr
+genAddr =
+    Addr
+        <$> elements [Mainnet, Testnet]
+        <*> (KeyHashObj <$> genKeyHash)
+        <*> pure StakeRefNull
+
+genKeyHash :: Gen (KeyHash kr)
+genKeyHash =
+    KeyHash
+        . fromMaybe err
+        . Crypto.hashFromBytes
+        <$> genHashBytes28
+  where
+    err = error "genKeyHash: invalid 28-byte hash"
+
+genHashBytes :: Gen ByteString
+genHashBytes = BS.pack <$> vectorOf 32 arbitrary
+
+genHashBytes28 :: Gen ByteString
+genHashBytes28 = BS.pack <$> vectorOf 28 arbitrary
+
+isReasonableConwayTxOut :: TxOut Conway -> Bool
+isReasonableConwayTxOut out =
+    coinFitsTxOut $ computeMinimumCoinForTxOut minPParams out
+  where
+    minPParams =
+        (def :: PParams Conway)
+            & ppCoinsPerUTxOByteL
+                .~ Ledger.CoinPerByte (Ledger.CompactCoin 1)
+
+isReasonableDijkstraTxOut :: TxOut Dijkstra -> Bool
+isReasonableDijkstraTxOut out =
+    coinFitsTxOut $ computeMinimumCoinForTxOut minPParams out
+  where
+    minPParams =
+        (def :: PParams Dijkstra)
+            & ppCoinsPerUTxOByteL
+                .~ Ledger.CoinPerByte (Ledger.CompactCoin 1)
+
+coinFitsTxOut :: Coin -> Bool
+coinFitsTxOut (Coin c) =
+    c >= 0 && c <= toInteger (maxBound :: Word64)
 
 {- | Allows 'testIsomorphism' to be called more conveniently when short on
 horizontal space, compared to a multiline "(a -> b, String)".


### PR DESCRIPTION
Closes #37

Bump all dependencies to match cardano-node 10.7.1.

## Changes

### 10.7.0 adaptations (earlier commits)
- ouroboros package consolidation (sublibrary syntax)
- ledger-core 1.19 API changes (Tx TopTx, KeyRole type data, etc.)
- EqRaw (NativeScript era) added to RecentEraConstraints
- Dijkstra era adaptations

### 10.7.1 bump (latest commit)
- ouroboros-consensus 1.0.0.0 → 3.0.1.0
- cardano-ledger-core 1.19 → 1.20
- cardano-ledger-conway 1.21 → 1.22
- CHaP index-state: 2026-03-23 → 2026-04-14
- hackage index-state: 2026-02-14 → 2026-03-26
- Removed version bounds from .cabal (managed in cabal.project)
- Updated flake.lock

No code changes needed for the 10.7.1 bump.

Note: `cabal build` inside `nix develop` is broken due to haskell.nix sublibrary issue (input-output-hk/haskell.nix#1662). `nix build` works correctly.