### PR TITLE
fix: add SafeToHash (NativeScript era) to RecentEraConstraints

### DIFF
--- a/lib/Cardano/Balance/Tx/Eras.hs
+++ b/lib/Cardano/Balance/Tx/Eras.hs
@@ -85,6 +85,9 @@ import qualified Cardano.Ledger.Alonzo.Core as Alonzo
 import qualified Cardano.Ledger.Api as Ledger
 import qualified Cardano.Ledger.Babbage.TxBody as Babbage
 import qualified Cardano.Ledger.Core as Core
+import Cardano.Ledger.Hashes
+    ( SafeToHash
+    )
 import Cardano.Ledger.MemoBytes
     ( EqRaw
     )
@@ -204,6 +207,7 @@ type RecentEraConstraints era =
       -- the full superclass chain through EraTx/EraTxWits/EraScript.
       -- All recent eras (Conway, Dijkstra) have this instance.
       EqRaw (Core.NativeScript era)
+    , SafeToHash (Core.NativeScript era)
     )
 
 instance IsRecentEra Conway where


### PR DESCRIPTION
## Summary

- Add `SafeToHash (Core.NativeScript era)` to `RecentEraConstraints` type alias
- The existing `EqRaw (NativeScript era)` constraint (added in 67dcacd) was insufficient — GHC also requires `SafeToHash` through the `EraScript` superclass chain

## Context

cardano-wallet fails to build against the current pin because `ExceptionBalanceTx` uses `IsRecentEra era` existentially, and GHC cannot derive `SafeToHash (NativeScript era)` from the available constraints.

Closes #39