### PR TITLE
chore: align node 11.0.1 dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,13 +27,13 @@ jobs:
         run: nix run .#unit-tests --quiet
 
       - name: Fourmolu
-        run: nix develop --command fourmolu -m check lib test
+        run: nix develop .#ci --command fourmolu -m check lib test
 
       - name: HLint
-        run: nix develop --command hlint lib test
+        run: nix develop .#ci --command hlint lib test
 
       - name: Nixfmt
-        run: nix develop --command nixfmt --check flake.nix nix/*.nix
+        run: nix develop .#ci --command nixfmt --check flake.nix nix/*.nix
 
   docs:
     runs-on: ubuntu-latest

--- a/cabal.project
+++ b/cabal.project
@@ -18,7 +18,7 @@ index-state: 2026-03-26T20:21:33Z
 
 index-state:
   , hackage.haskell.org 2026-03-26T20:21:33Z
-  , cardano-haskell-packages 2026-04-14T21:25:56Z
+  , cardano-haskell-packages 2026-05-02T16:21:41Z
 
 packages:
   .
@@ -54,7 +54,28 @@ allow-newer:
 
 constraints:
     base >= 4.18.2.0 && < 5
+  , cardano-addresses ==4.0.2
+  , cardano-binary ==1.8.0.0
+  , cardano-crypto-class ==2.3.2.0
+  , cardano-crypto-wrapper ==1.7.0.0
+  , cardano-ledger-allegra ==1.9.0.0
+  , cardano-ledger-alonzo ==1.15.0.1
+  , cardano-ledger-alonzo-test ==1.4.0.1
+  , cardano-ledger-api ==1.13.0.0
+  , cardano-ledger-babbage ==1.13.0.0
+  , cardano-ledger-binary ==1.8.1.0
+  , cardano-ledger-byron ==1.3.0.0
+  , cardano-ledger-conway ==1.22.1.0
+  , cardano-ledger-core ==1.20.0.0
+  , cardano-ledger-dijkstra ==0.2.0.1
+  , cardano-ledger-mary ==1.10.0.0
+  , cardano-ledger-shelley ==1.18.1.0
+  , cardano-ledger-shelley-ma-test ==1.4.0.2
+  , cardano-protocol-tpraos ==1.5.0.0
+  , cardano-slotting ==0.2.1.0
+  , cardano-strict-containers ==0.1.6.0
   , openapi3 >= 3.2.0
+  , ouroboros-consensus ==3.0.1.0
 
 package cardano-coin-selection
   tests: False

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1776203472,
-        "narHash": "sha256-husRfOULFemi5q+JpO7deykZxTKSIz0E4fCR387aO3Y=",
+        "lastModified": 1777742585,
+        "narHash": "sha256-ZzXz2vOhqethlqPgBExPXEnKWvaTbidsIxh5MGv+pwE=",
         "owner": "intersectmbo",
         "repo": "cardano-haskell-packages",
-        "rev": "3831817e4131b3ef5fe262e3f853b87bec8a24a0",
+        "rev": "e8a483522ee73c8c9493ea6055553e5c2532e66b",
         "type": "github"
       },
       "original": {

--- a/justfile
+++ b/justfile
@@ -29,21 +29,22 @@ hlint:
     #!/usr/bin/env bash
     hlint lib test
 
-# Build all components
+# Build all components through the same flake path used by CI
 build:
     #!/usr/bin/env bash
-    cabal build all -O0 --enable-tests
+    nix build --accept-flake-config --allow-import-from-derivation --quiet \
+        .#lib .#unit-tests
 
 # Run unit tests with optional match pattern
 unit match="":
     #!/usr/bin/env bash
     if [[ '{{ match }}' == "" ]]; then
-        cabal test unit -O0 --enable-tests --test-show-details=direct
+        nix run --accept-flake-config --allow-import-from-derivation --quiet \
+            .#unit-tests
     else
-        cabal test unit -O0 --enable-tests \
-            --test-show-details=direct \
-            --test-option=--match \
-            --test-option="{{ match }}"
+        nix run --accept-flake-config --allow-import-from-derivation --quiet \
+            .#unit-tests -- \
+            --match "{{ match }}"
     fi
 
 # Full CI pipeline

--- a/nix/project.nix
+++ b/nix/project.nix
@@ -16,8 +16,7 @@ let
         cardano-ledger-conway.components.sublibs.testlib
         cardano-ledger-mary.components.sublibs.testlib
       ];
-    # GHC 9.12.2 haddock panics on tyConStupidTheta; disable until fixed
-    withHoogle = false;
+    withHoogle = true;
     buildInputs = [
       pkgs.just
       pkgs.nixfmt-classic
@@ -27,12 +26,19 @@ let
       pkgs.haskellPackages.cabal-fmt
     ];
   };
+  ciShell = { pkgs, ... }: {
+    tools = {
+      fourmolu = { index-state = indexState; };
+      hlint = { index-state = indexState; };
+    };
+    withHoogle = false;
+    buildInputs = [ pkgs.just pkgs.nixfmt-classic ];
+  };
 
   mkProject = { lib, pkgs, ... }: {
     name = "cardano-balance-tx";
     src = ./..;
-    compiler-nix-name = "ghc9122";
-    shell = shell { inherit pkgs; };
+    compiler-nix-name = "ghc9123";
     inputMap = { "https://chap.intersectmbo.org/" = CHaP; };
     modules = [
       ({ lib, pkgs, ... }: {
@@ -47,7 +53,10 @@ let
   project = pkgs.haskell-nix.cabalProject' mkProject;
 
 in {
-  devShells.default = project.shell;
+  devShells = {
+    default = project.shellFor shell;
+    ci = project.shellFor ciShell;
+  };
   inherit project;
   packages.lib = project.hsPkgs.cardano-balance-tx.components.library;
   packages.unit-tests = project.hsPkgs.cardano-balance-tx.components.tests.unit;


### PR DESCRIPTION
Closes #41

## Summary
- align CHaP index-state and lock with cardano-node 11.0.1
- pin Cardano package constraints to the node 11.0.1 freeze surface
- harmonize haskell.nix with wallet ghc9123 and enable Hoogle in the dev shell

## Validation
- `nix-instantiate --parse nix/project.nix`
- `git diff --check`
- started `nix develop --accept-flake-config --allow-import-from-derivation --quiet -c bash -lc 'ghc --numeric-version && hoogle --version && just build'`; stopped before completion to push the draft PR and warm remote builders