### PR TITLE
docs: correct supported eras and bring docs to the org standard

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,48 @@
+# Repository Agent Guide
+
+## What this repo is
+
+`cardano-balance-tx` is a standalone Haskell library that balances
+Cardano transactions: given a partial transaction (user-specified
+outputs, but incomplete inputs and fees), a UTxO set, and protocol
+parameters, its single public entry point `balanceTx` produces a fully
+balanced, ready-to-sign transaction. It was extracted from
+`cardano-wallet`'s `lib/balance-tx/` and works directly with
+`cardano-ledger` types, targeting the two most recent eras (Conway and
+Dijkstra). There is **no executable** — it is consumed as a library.
+
+## How to work here
+
+All recipes route through the flake, matching CI
+(`.github/workflows/ci.yml`):
+
+- Enter the dev shell: `nix develop`
+- Build (lib + tests): `just build`  (`nix build .#lib .#unit-tests`)
+- Run tests: `just unit`  (`nix run .#unit-tests`); filter with
+  `just unit "<match>"`
+- Full local CI: `just CI`  (build + tests + fourmolu + hlint + nixfmt)
+- Format: `just format`  (fourmolu, cabal-fmt, nixfmt)
+- Lint: `just hlint`
+- Docs: `just docs-serve` / `just docs-build` (`mkdocs build --strict`)
+
+Inside `nix develop` you can also use cabal directly with `-O0`, e.g.
+`cabal build lib:cardano-balance-tx -O0` and `cabal test unit -O0`.
+
+Source lives in `lib/Cardano/Balance/Tx/`; tests in `test/spec/` with
+fixtures in `test/data/`. Dependency pins are in `cabal.project`; the
+package metadata is in `cardano-balance-tx.cabal`.
+
+## Skills
+
+Activatable procedures live under `skills/`. Load the one whose
+description matches your task:
+
+- `skills/cardano-balance-transaction-guide/` — repository map, build/test
+  commands, how to navigate the code, how to use `balanceTx`, and where
+  answers to common questions about this repo live.
+
+## Documentation
+
+Human-facing docs are in `docs/` and published at
+<https://cardano-foundation.github.io/cardano-balance-transaction/>. The
+`README.md` is the entry point.

--- a/README.md
+++ b/README.md
@@ -7,100 +7,164 @@
 Standalone Cardano transaction balancing library, extracted from
 [cardano-wallet](https://github.com/cardano-foundation/cardano-wallet).
 
-## Overview
+## What is this
 
-`cardano-balance-tx` takes a partial Cardano transaction (with
-user-specified outputs but incomplete inputs and fees) and produces a
-fully balanced, ready-to-sign transaction. It handles:
+`cardano-balance-tx` takes a partial Cardano transaction — one with
+user-specified outputs but incomplete inputs and fees — and produces a
+fully balanced, ready-to-sign transaction. The single public entry point
+is `balanceTx` in `Cardano.Balance.Tx.Balance`.
+
+It handles:
 
 - **Coin selection** — choosing UTxO inputs to cover outputs, fees, and
   collateral (via
   [cardano-coin-selection](https://github.com/cardano-foundation/cardano-coin-selection))
-- **Fee estimation** — computing minimum fees from transaction size and
-  protocol parameters
+- **Fee estimation** — computing minimum fees from estimated transaction
+  size and protocol parameters
 - **Change output construction** — distributing surplus ada and native
   tokens back to the wallet
 - **Surplus distribution** — splitting fee surplus between fee padding
   and change outputs
 - **Token bundle size validation** — ensuring outputs don't exceed
   ledger limits
-- **Redeemer assignment** — updating Plutus script redeemer indices
+- **Redeemer assignment** — reindexing Plutus script redeemer pointers
   after input selection
 - **Transaction size estimation** — predicting serialized size before
   final encoding
-- **Multi-era support** — Babbage and Conway eras
 
 The library works directly with `cardano-ledger` types, avoiding any
-wallet-specific type abstractions.
+wallet-specific type abstractions. It targets the two most recent eras
+(see [Supported eras](#supported-eras)).
 
-## Modules
+## Architecture
+
+`balanceTx` runs an iterative pipeline. Because adding inputs changes the
+transaction size and therefore the fee, the algorithm repeats coin
+selection and change construction until the fee stabilises.
+
+```mermaid
+flowchart TD
+    A["Partial Tx<br/>+ UTxO<br/>+ Protocol Params"] --> B["1. Coin selection<br/>(Balance.CoinSelection)"]
+    B --> C["2. Fee &amp; size estimation<br/>(SizeEstimation, Sign)"]
+    C --> D["3. Change construction<br/>(Balance.Surplus, Balance.TokenBundleSize)"]
+    D --> E{"Fee stabilised?"}
+    E -- "No" --> B
+    E -- "Yes" --> F["4. Redeemer assignment<br/>(Redeemers)"]
+    F --> G["5. Validation"]
+    G --> H["Balanced Tx<br/>(ready to sign)"]
+```
+
+See [docs/architecture.md](docs/architecture.md) for the full module
+breakdown.
+
+## Supported eras
+
+The library defines a `RecentEra` GADT covering the **two most recent
+eras**, so the same code can construct transactions on either side of a
+hard fork:
+
+- Conway
+- Dijkstra
+
+(Babbage and earlier are modelled as non-recent eras; serialization
+round-trip tests still cover Babbage golden fixtures for backwards
+compatibility.)
+
+## Install
+
+This is a Haskell library, not an executable. Consume it from another
+project by adding it as a `source-repository-package` to your
+`cabal.project`:
+
+```cabal
+source-repository-package
+  type: git
+  location: https://github.com/cardano-foundation/cardano-balance-transaction
+  tag: <commit-sha>
+```
+
+You also need the Cardano Haskell Package repository
+([CHaP](https://github.com/IntersectMBO/cardano-haskell-packages)) and a
+matching `index-state`; see [cabal.project](cabal.project) for the pins
+this repository builds against (GHC 9.12.2).
+
+## Quickstart
+
+```bash
+# Clone and enter the Nix devShell (provides GHC, cabal, and CHaP access)
+git clone https://github.com/cardano-foundation/cardano-balance-transaction
+cd cardano-balance-transaction
+nix develop
+
+# Build the library and run the tests via the flake (the CI path)
+just build
+just unit
+```
+
+## Usage
+
+The public surface is a single function. Everything else in
+`Cardano.Balance.Tx.Balance` supports calling it (errors, change-address
+generation, partial-transaction inputs):
+
+```haskell
+balanceTx
+    :: forall era m changeState
+     . (MonadRandom m, IsRecentEra era)
+    => PParams era            -- ^ Protocol parameters
+    -> TimeTranslation        -- ^ Slot/time translation for Plutus scripts
+    -> UTxOAssumptions        -- ^ Script assumptions for size estimation
+    -> UTxOIndex era          -- ^ Available UTxO to select inputs from
+    -> ChangeAddressGen changeState
+    -> changeState
+    -> PartialTx era          -- ^ Transaction to balance
+    -> ExceptT (ErrBalanceTx era) m (Tx era, changeState)
+```
+
+Exposed modules:
 
 | Module | Description |
 |--------|-------------|
-| `Cardano.Balance.Tx.Balance` | Main `balanceTx` entry point and error types |
-| `Cardano.Balance.Tx.Balance.CoinSelection` | Adapter bridging ledger types to coin-selection |
+| `Cardano.Balance.Tx.Balance` | Main `balanceTx` entry point, error types, `PartialTx`, change-address generation |
+| `Cardano.Balance.Tx.Balance.CoinSelection` | Adapter bridging ledger types to `cardano-coin-selection` |
 | `Cardano.Balance.Tx.Balance.Surplus` | Surplus distribution between fees and change |
 | `Cardano.Balance.Tx.Balance.TokenBundleSize` | Token bundle size assessment |
-| `Cardano.Balance.Tx.Eras` | Era definitions and constraints (`RecentEra`) |
-| `Cardano.Balance.Tx.Gen` | QuickCheck generators for protocol parameters and datums |
-| `Cardano.Balance.Tx.Primitive` | Lightweight primitive types (qualified import as `W`) |
+| `Cardano.Balance.Tx.Eras` | `RecentEra` GADT and constraints (Conway, Dijkstra) |
+| `Cardano.Balance.Tx.Gen` | QuickCheck generators for protocol parameters and datum hashes |
+| `Cardano.Balance.Tx.Primitive` | Lightweight primitive value types (import qualified as `W`) |
 | `Cardano.Balance.Tx.Primitive.Convert` | Conversions between primitive and ledger types |
 | `Cardano.Balance.Tx.Primitive.Gen` | QuickCheck generators for primitive types |
 | `Cardano.Balance.Tx.Redeemers` | Plutus redeemer index assignment |
-| `Cardano.Balance.Tx.Sign` | Transaction signing utilities |
+| `Cardano.Balance.Tx.Sign` | Signing-related size/fee estimation and witness counting |
 | `Cardano.Balance.Tx.SizeEstimation` | Transaction size and cost estimation |
 | `Cardano.Balance.Tx.TimeTranslation` | Slot/time translation from epoch info |
-| `Cardano.Balance.Tx.Tx` | Transaction types and key witness counting |
+| `Cardano.Balance.Tx.Tx` | Transaction/PParams types, serialization, minimum-ada computation |
 | `Cardano.Balance.Tx.TxWithUTxO` | Transaction paired with its resolved UTxO |
 | `Cardano.Balance.Tx.TxWithUTxO.Gen` | Generators for `TxWithUTxO` |
 | `Cardano.Balance.Tx.UTxOAssumptions` | UTxO script assumptions for size estimation |
 
-## Quick start
-
-```bash
-# Enter the Nix devShell
-nix develop
-
-# Build
-cabal build lib:cardano-balance-tx -O0
-
-# Run tests (268 examples)
-cabal test unit -O0
-```
-
-## How it works
-
-The balancing algorithm follows a pipeline:
-
-1. **Select inputs** — run coin selection to pick UTxO entries that
-   cover the requested outputs plus estimated fees
-2. **Estimate fees** — compute the minimum fee from the partially
-   assembled transaction and protocol parameters
-3. **Construct change** — distribute surplus ada and native tokens into
-   change outputs, respecting token bundle size limits
-4. **Assign redeemers** — reindex Plutus redeemer pointers to reflect
-   the final input ordering
-5. **Validate** — check the balanced transaction against ledger rules
-
-The algorithm iterates when fee estimates change after adding inputs
-(more inputs = larger transaction = higher fee), converging when the fee
-stabilizes.
-
-## Supported eras
-
-- Babbage
-- Conway
-
 ## Documentation
 
-Full documentation is available at
+Full documentation is published at
 <https://cardano-foundation.github.io/cardano-balance-transaction/>.
 
-## Key dependencies
+For AI agents, start at [AGENTS.md](AGENTS.md).
 
-- `cardano-ledger-*` — core ledger types and validation
-- `cardano-coin-selection` — coin selection algorithm
-- `ouroboros-consensus` — consensus protocol types
+## Development
+
+All recipes go through the same flake path used by CI:
+
+```bash
+just build        # nix build .#lib .#unit-tests
+just unit         # run the unit test suite (optionally: just unit "<match>")
+just CI           # build + tests + fourmolu + hlint + nixfmt
+just format       # fourmolu, cabal-fmt, nixfmt
+just docs-serve   # serve the MkDocs site locally
+just docs-build   # mkdocs build --strict
+```
+
+Inside `nix develop` you can also drive cabal directly, e.g.
+`cabal build lib:cardano-balance-tx -O0` and `cabal test unit -O0`.
 
 ## Origin
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -12,13 +12,13 @@ signing. The core entry point is `balanceTx` in
 ```mermaid
 flowchart TD
     A["Partial Tx + UTxO + Protocol Params"] --> B
-    B["1. Coin Selection\n(CoinSelection)"]
+    B["1. Coin Selection<br/>(CoinSelection)"]
     B -- "inputs selected" --> C
-    C["2. Fee Estimation\n(SizeEstimation)"]
+    C["2. Fee Estimation<br/>(SizeEstimation, Sign)"]
     C -- "fee computed" --> D
-    D["3. Change Outputs\n(Surplus, TokenBundleSize)"]
+    D["3. Change Outputs<br/>(Surplus, TokenBundleSize)"]
     D -- "change distributed" --> E
-    E["4. Redeemer Assignment\n(Redeemers)"]
+    E["4. Redeemer Assignment<br/>(Redeemers)"]
     E -- "redeemers reindexed" --> F
     F["5. Validation"]
     F --> G["Balanced Tx (ready to sign)"]
@@ -55,9 +55,10 @@ The library is organized into three layers:
 - **`Primitive`** — lightweight value types (coin, token bundle,
   address) inlined from `cardano-wallet-primitive`, bridging to ledger
   types via `Primitive.Convert`
-- **`Tx`** — transaction-level types, key witness counting
+- **`Tx`** — transaction/PParams types, serialization, key witness
+  counting, minimum-ada computation
 - **`TxWithUTxO`** — a transaction paired with its resolved UTxO context
-- **`Eras`** — era definitions (`RecentEra` covering Babbage/Conway)
+- **`Eras`** — era definitions (`RecentEra` covering Conway/Dijkstra)
 
 ### Balancing logic
 
@@ -73,7 +74,8 @@ The library is organized into three layers:
 
 - **`SizeEstimation`** — predicting serialized transaction size
 - **`Redeemers`** — assigning script redeemer indices
-- **`Sign`** — transaction signing
+- **`Sign`** — signing-related size/fee estimation and witness counting
+  (`estimateSignedTxSize`, `estimateSignedTxMinFee`, `KeyWitnessCounts`)
 - **`TimeTranslation`** — slot/time conversion from epoch info
 - **`UTxOAssumptions`** — assumptions about UTxO script types for size
   estimation
@@ -110,6 +112,10 @@ graph TD
 
 ## Era support
 
-The library uses a `RecentEra` GADT to support Babbage and Conway. All
-era-specific logic is isolated in `Eras` and pattern-matched where
-needed, keeping the core balancing algorithm era-polymorphic.
+The library uses a `RecentEra` GADT to support the two most recent eras
+— Conway and Dijkstra — so the same code can construct transactions on
+either side of a hard fork. All era-specific logic is isolated in `Eras`
+and pattern-matched where needed, keeping the core balancing algorithm
+era-polymorphic. (Babbage and earlier are modelled as non-recent eras;
+serialization round-trip tests still cover Babbage golden fixtures for
+backwards compatibility.)

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -16,10 +16,19 @@ cd cardano-balance-transaction
 # Enter the development shell
 nix develop
 
-# Build the library
-cabal build lib:cardano-balance-tx -O0
+# Build the library and tests through the same flake path used by CI
+just build
 
 # Run the test suite
+just unit
+```
+
+`just build` runs `nix build .#lib .#unit-tests` and `just unit` runs
+`nix run .#unit-tests`; both match the CI workflow. Inside `nix develop`
+you can also drive cabal directly:
+
+```bash
+cabal build lib:cardano-balance-tx -O0
 cabal test unit -O0
 ```
 
@@ -44,14 +53,22 @@ cabal test unit -O0
 
 ## Test suite
 
-The test suite contains 268 property tests and golden tests ported
-from `cardano-wallet`. Run with:
+The test suite combines QuickCheck property tests with golden tests
+ported from `cardano-wallet` (including serialization round-trips across
+the Babbage, Conway, and Dijkstra golden fixtures under `test/data/`).
+Run it with:
 
 ```bash
-cabal test unit -O0
+just unit
 ```
 
-To run with verbose output:
+Filter to a subset by passing a match pattern:
+
+```bash
+just unit "Surplus"
+```
+
+Or, inside `nix develop`, with verbose cabal output:
 
 ```bash
 cabal test unit -O0 --test-show-details=direct
@@ -59,11 +76,14 @@ cabal test unit -O0 --test-show-details=direct
 
 ## Documentation site
 
-Build the MkDocs documentation locally:
+Build or serve the MkDocs documentation locally:
 
 ```bash
-nix develop
-mkdocs serve
+just docs-serve   # serve at http://127.0.0.1:8000
+just docs-build   # mkdocs build --strict
 ```
 
-Then open <http://127.0.0.1:8000>.
+`just docs-serve` runs `mkdocs serve` and `just docs-build` runs
+`mkdocs build --strict`. The MkDocs toolchain is provided by the
+`github:paolino/dev-assets?dir=mkdocs` flake (see the `docs` job in
+`.github/workflows/ci.yml`).

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,13 +10,13 @@ fully balanced, ready-to-sign transaction.
 
 The library handles coin selection, fee estimation, change construction,
 surplus distribution, token bundle size validation, Plutus redeemer
-assignment, and transaction size estimation across Babbage and Conway
-eras.
+assignment, and transaction size estimation across the Conway and
+Dijkstra eras.
 
 ```mermaid
 flowchart LR
-    A["Partial Tx\n+ UTxO\n+ Protocol Params"] --> B["balanceTx"]
-    B --> C["Balanced Tx\n(ready to sign)"]
+    A["Partial Tx<br/>+ UTxO<br/>+ Protocol Params"] --> B["balanceTx"]
+    B --> C["Balanced Tx<br/>(ready to sign)"]
 ```
 
 ## Getting started

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -29,8 +29,9 @@ length allowed by the ledger. Exports `TokenBundleSizeAssessor`,
 
 ### `Cardano.Balance.Tx.Eras`
 
-Era definitions. The `RecentEra` GADT covers Babbage and Conway,
-with associated type families and constraints.
+Era definitions. The `RecentEra` GADT covers the two most recent eras
+— Conway and Dijkstra — with associated type families and constraints
+(`IsRecentEra`, `RecentEraConstraints`, `AnyRecentEra`).
 
 ### `Cardano.Balance.Tx.Primitive`
 
@@ -45,9 +46,12 @@ Conversions between primitive types and ledger types. Replaces
 
 ### `Cardano.Balance.Tx.Tx`
 
-Transaction-level types: `KeyWitnessCounts`, partial transaction
-construction, and serialization utilities. Covers both Babbage and
-Conway representations.
+Transaction and protocol-parameter types: `KeyWitnessCounts`,
+`PParamsInAnyRecentEra`, transaction serialization (`serializeTx`,
+`deserializeTx`), `TxOut` handling, and minimum-ada computation
+(`computeMinimumCoinForTxOut`). The underlying `TxOut` representation is
+the shared `BabbageTxOut`, reused by both recent eras (Conway and
+Dijkstra).
 
 ### `Cardano.Balance.Tx.TxWithUTxO`
 
@@ -64,7 +68,12 @@ input set, redeemer indices must be updated to match the new ordering.
 
 ### `Cardano.Balance.Tx.Sign`
 
-Transaction signing utilities for the balancing process.
+Signing-related size and fee estimation required during balancing.
+Exports `estimateSignedTxSize`, `estimateSignedTxMinFee`,
+`KeyWitnessCounts`, `TimelockKeyWitnessCounts`, and the witness-count
+estimators (`estimateKeyWitnessCounts`,
+`estimateMaxWitnessRequiredPerInput`). (Actual transaction signing is
+not yet implemented here — see the module's `TODO`.)
 
 ### `Cardano.Balance.Tx.SizeEstimation`
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,12 +1,26 @@
 site_name: cardano-balance-tx
 site_description: Standalone Cardano transaction balancing library
+site_url: https://cardano-foundation.github.io/cardano-balance-transaction/
 repo_url: https://github.com/cardano-foundation/cardano-balance-transaction
 theme:
   name: material
   palette:
-    scheme: slate
-    primary: blue
-    accent: light blue
+    # Light mode
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: blue
+      accent: light blue
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    # Dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: blue
+      accent: light blue
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
   features:
     - navigation.sections
     - content.code.copy

--- a/skills/cardano-balance-transaction-guide/SKILL.md
+++ b/skills/cardano-balance-transaction-guide/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: cardano-balance-transaction-guide
+description: >-
+  Guide for working in the cardano-balance-transaction repository (the
+  cardano-balance-tx Haskell library). Load when a task involves balancing
+  Cardano transactions, the balanceTx entry point, coin selection, fee/size
+  estimation, change construction, surplus distribution, token bundle size
+  validation, Plutus redeemer reindexing, or the RecentEra (Conway/Dijkstra)
+  abstraction. Triggers include: cardano-balance-tx, cardano-balance-transaction,
+  balanceTx, PartialTx, ErrBalanceTx, UTxOIndex, ChangeAddressGen, RecentEra,
+  IsRecentEra, RecentEraConway, RecentEraDijkstra, distributeSurplus,
+  TokenBundleSizeAssessor, estimateTxSize, estimateTxCost, assignScriptRedeemers,
+  TimeTranslation, UTxOAssumptions, cardano-coin-selection, cardano-ledger,
+  lib/Cardano/Balance/Tx, "just build", "just unit", "nix run .#unit-tests",
+  GHC 9.12.2, or questions about which Cardano eras this library supports.
+---
+
+# cardano-balance-transaction guide
+
+Standalone Haskell library (no executable) that turns a partial Cardano
+transaction into a fully balanced, ready-to-sign one. The single public
+entry point is `balanceTx`. Targets the two most recent eras: **Conway
+and Dijkstra**.
+
+## Repository map
+
+| Path | Purpose |
+|------|---------|
+| `lib/Cardano/Balance/Tx/Balance.hs` | `balanceTx` entry point, `ErrBalanceTx*` errors, `PartialTx`, `ChangeAddressGen`, `UTxOIndex`, `updateTx` |
+| `lib/Cardano/Balance/Tx/Balance/CoinSelection.hs` | Adapter to `cardano-coin-selection` (selection params/constraints/strategy) |
+| `lib/Cardano/Balance/Tx/Balance/Surplus.hs` | `distributeSurplus`, `TxFeeAndChange`, surplus delta math |
+| `lib/Cardano/Balance/Tx/Balance/TokenBundleSize.hs` | `TokenBundleSizeAssessor`, `mkTokenBundleSizeAssessor` |
+| `lib/Cardano/Balance/Tx/Eras.hs` | `RecentEra` GADT, `IsRecentEra`, `RecentEraConstraints`, `AnyRecentEra` (Conway, Dijkstra) |
+| `lib/Cardano/Balance/Tx/Tx.hs` | `Tx`/`PParams` types, `serializeTx`/`deserializeTx`, `TxOut`, min-ada |
+| `lib/Cardano/Balance/Tx/TxWithUTxO.hs` | `TxWithUTxO` (+ `construct`, `constructFiltered`) |
+| `lib/Cardano/Balance/Tx/Sign.hs` | `estimateSignedTxSize`, `estimateSignedTxMinFee`, witness counting |
+| `lib/Cardano/Balance/Tx/SizeEstimation.hs` | `estimateTxSize`, `estimateTxCost`, `TxSkeleton` |
+| `lib/Cardano/Balance/Tx/Redeemers.hs` | `assignScriptRedeemers`, `ErrAssignRedeemers` |
+| `lib/Cardano/Balance/Tx/TimeTranslation.hs` | `TimeTranslation`, `timeTranslationFromEpochInfo` |
+| `lib/Cardano/Balance/Tx/UTxOAssumptions.hs` | `UTxOAssumptions`, `assumedInputScriptTemplate` |
+| `lib/Cardano/Balance/Tx/Primitive.hs` + `Primitive/Convert.hs` | Lightweight value types (qualified `W`) and ledger conversions |
+| `lib/Cardano/Balance/Tx/{Gen,Primitive/Gen,TxWithUTxO/Gen}.hs` | QuickCheck generators |
+| `test/spec/` | Hspec/QuickCheck specs; `test/data/` | golden fixtures (`babbage/`, `conway/`, `dijkstra/`, `signedTxs/`) |
+| `cabal.project` / `cardano-balance-tx.cabal` | Dependency pins (CHaP + GHC 9.12.2) and package metadata |
+| `flake.nix` / `nix/project.nix` / `justfile` | Build tooling |
+| `docs/` / `mkdocs.yml` | MkDocs site |
+
+## Build, test, run
+
+Everything routes through the flake (same as `.github/workflows/ci.yml`):
+
+```bash
+nix develop                  # dev shell (GHC 9.12.2, cabal, CHaP access)
+just build                   # nix build .#lib .#unit-tests
+just unit                    # nix run .#unit-tests
+just unit "Surplus"          # run a matching subset
+just CI                      # build + tests + fourmolu + hlint + nixfmt
+just format                  # fourmolu, cabal-fmt, nixfmt
+just docs-build              # mkdocs build --strict
+```
+
+Inside `nix develop`, cabal works too: `cabal build lib:cardano-balance-tx -O0`,
+`cabal test unit -O0`.
+
+## Navigating the code
+
+- Start at `balanceTx` in `Balance.hs` (defined around line 529). Its
+  internal worker is `balanceTxInner`. The module re-exports the selection,
+  surplus, and error types callers need.
+- The balancing loop is iterative: add inputs → re-estimate fee/size →
+  recompute change → repeat until the fee stabilises, then assign
+  redeemers and validate.
+- Era handling is centralised in `Eras.hs`: pattern-match `RecentEra era`
+  (`RecentEraConway` / `RecentEraDijkstra`); add era constraints via
+  `IsRecentEra` / `RecentEraConstraints`. To support a new era you touch
+  `Eras.hs` first.
+- Ledger ↔ primitive conversions live in `Primitive/Convert.hs`
+  (`toConwayTxOut`, `toDijkstraTxOut`, `toLedgerCoin`, …).
+
+## Using cardano-balance-tx
+
+Consume it as a library (`source-repository-package` in `cabal.project`).
+The public surface is one function:
+
+```haskell
+balanceTx
+    :: forall era m changeState
+     . (MonadRandom m, IsRecentEra era)
+    => PParams era
+    -> TimeTranslation
+    -> UTxOAssumptions
+    -> UTxOIndex era
+    -> ChangeAddressGen changeState
+    -> changeState
+    -> PartialTx era
+    -> ExceptT (ErrBalanceTx era) m (Tx era, changeState)
+```
+
+- Build the `UTxOIndex era` with `constructUTxOIndex`.
+- Failures come back as `ErrBalanceTx era` (e.g.
+  `ErrBalanceTxAssetsInsufficientError`,
+  `ErrBalanceTxUnableToCreateChangeError`,
+  `ErrBalanceTxInsufficientCollateralError`).
+- The era type parameter must satisfy `IsRecentEra` — instantiate it at
+  `Conway` or `Dijkstra`.
+
+## Answering questions
+
+- **"What does this library do / how does balancing work?"** →
+  `README.md` ("What is this", "Architecture") and
+  `docs/architecture.md` (pipeline + iteration diagrams).
+- **"Which eras are supported?"** → Conway and Dijkstra (the two most
+  recent eras). Source of truth: `RecentEra` in `lib/Cardano/Balance/Tx/Eras.hs`.
+  Babbage is a *non-recent* era kept only for serialization round-trip
+  fixtures.
+- **"How do I call it / what's the API?"** → README "Usage" and
+  `docs/modules.md`; the signature is `balanceTx` in `Balance.hs`.
+- **"How do I build/test it?"** → `README.md` "Development",
+  `docs/getting-started.md`, the `justfile`, and `.github/workflows/ci.yml`.
+- **"Where did it come from?"** → `NOTICE` and the README "Origin"
+  section (extracted from `cardano-wallet` `lib/balance-tx/`).
+- When a user claims a behaviour the docs don't cover, verify against the
+  source under `lib/Cardano/Balance/Tx/` before answering.


### PR DESCRIPTION
Documentation review against the current state of the code. Docs-only
changes — no source, tests, CI, or build tooling were touched.

## What was inaccurate

- **Supported eras were wrong.** The README and every docs page stated
  the library supports *Babbage and Conway*. The `RecentEra` GADT in
  `lib/Cardano/Balance/Tx/Eras.hs` actually covers **Conway and
  Dijkstra** (`RecentEraConway`, `RecentEraDijkstra`; `IsRecentEra`
  instances for `Conway`/`Dijkstra`; `LatestLedgerEra = DijkstraEra`).
  Babbage is modelled as a non-recent era. The cabal `description`
  already said "Conway and Dijkstra"; the prose had drifted. Confirmed
  further by `Primitive/Convert.hs` (`toConwayTxOut`/`toDijkstraTxOut`,
  no Babbage) and the `test/data/.../dijkstra/` fixtures.
- **Mermaid diagrams used literal `\n`** inside node labels, which
  renders as backslash-n rather than a line break. Replaced with `<br/>`.
- **Unverified test count.** Docs claimed "268 property tests"; I could
  not verify the exact number, so it is replaced with a description of
  the suite (QuickCheck properties + golden round-trips across the
  Babbage/Conway/Dijkstra fixtures).
- **Stale module descriptions.** `Sign` was described as "transaction
  signing", but it exports size/fee estimation and witness-counting
  helpers (signing itself is a `TODO`). `Tx` was described as doing
  "partial transaction construction across Babbage and Conway"; it
  actually provides PParams types, serialization, `TxOut` handling, and
  min-ada computation.
- **Build commands** documented raw `cabal` only; CI actually drives the
  flake (`nix build .#lib`, `nix run .#unit-tests`) via `just` recipes.

## What changed

- `README.md`: restructured into the standard section order (What is
  this / Architecture / Supported eras / Install / Quickstart / Usage /
  Documentation / Development / Origin / License), added a mermaid
  pipeline diagram, the real `balanceTx` signature, a verified module
  table, and a `source-repository-package` consumption snippet.
- `docs/index.md`, `docs/architecture.md`, `docs/modules.md`: corrected
  era references, fixed mermaid line breaks, tightened `Tx`/`Sign`
  descriptions.
- `docs/getting-started.md`: aligned build/test/docs commands with the
  `just` recipes and the mkdocs flake CI uses.
- `mkdocs.yml`: added a light/dark palette toggle and `site_url`.
- `AGENTS.md` + `skills/cardano-balance-transaction-guide/SKILL.md`: new
  agent layer (repository map, build/test commands, code navigation,
  `balanceTx` usage, answering-questions pointers).

## Verification

- Every module/symbol claim checked against the export lists in
  `lib/Cardano/Balance/Tx/**` (e.g. `distributeSurplus`,
  `mkTokenBundleSizeAssessor`, `estimateTxSize`/`estimateTxCost`,
  `toLedgerCoin`, `timeTranslationFromEpochInfo`,
  `construct`/`constructFiltered`, `assignScriptRedeemers`).
- `balanceTx` signature copied from `Balance.hs`.
- Build/test commands cross-checked against `justfile` and
  `.github/workflows/ci.yml`.
- Diagrams validated node-by-node against the balancing pipeline and the
  module dependency graph in `Balance.hs`.
- `mkdocs build --strict` runs clean (built in 0.51s, no warnings) via
  `nix develop github:paolino/dev-assets?dir=mkdocs`.
