### PR TITLE
chore: move pin set from cardano-node 11.0.1 to 11.1.0

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -14,11 +14,11 @@ repository cardano-haskell-packages
     c00aae8461a256275598500ea0e187588c35a5d5d7454fb57eac18d9edb86a56
     d4a35cd3121aa00d18544bb0ac01c3e1691d618f462c46129271bccf39f7e8ee
 
-index-state: 2026-03-26T20:21:33Z
+index-state: 2026-08-14T13:38:07Z
 
 index-state:
-  , hackage.haskell.org 2026-03-26T20:21:33Z
-  , cardano-haskell-packages 2026-05-02T16:21:41Z
+  , hackage.haskell.org 2026-08-14T13:38:07Z
+  , cardano-haskell-packages 2026-08-17T11:39:16Z
 
 packages:
   .
@@ -55,27 +55,27 @@ allow-newer:
 constraints:
     base >= 4.18.2.0 && < 5
   , cardano-addresses ==4.0.2
-  , cardano-binary ==1.8.0.0
-  , cardano-crypto-class ==2.3.2.0
+  , cardano-binary ==1.9.1.0
+  , cardano-crypto-class ==2.5.1.0
   , cardano-crypto-wrapper ==1.7.0.0
-  , cardano-ledger-allegra ==1.9.0.0
-  , cardano-ledger-alonzo ==1.15.0.1
+  , cardano-ledger-allegra ==1.10.0.0
+  , cardano-ledger-alonzo ==1.16.0.0
   , cardano-ledger-alonzo-test ==1.4.0.1
-  , cardano-ledger-api ==1.13.0.0
-  , cardano-ledger-babbage ==1.13.0.0
-  , cardano-ledger-binary ==1.8.1.0
+  , cardano-ledger-api ==1.14.0.0
+  , cardano-ledger-babbage ==1.14.0.0
+  , cardano-ledger-binary ==1.9.0.0
   , cardano-ledger-byron ==1.3.0.0
-  , cardano-ledger-conway ==1.22.1.0
-  , cardano-ledger-core ==1.20.0.0
-  , cardano-ledger-dijkstra ==0.2.0.1
-  , cardano-ledger-mary ==1.10.0.0
-  , cardano-ledger-shelley ==1.18.1.0
+  , cardano-ledger-conway ==1.23.0.0
+  , cardano-ledger-core ==1.21.0.0
+  , cardano-ledger-dijkstra ==0.3.0.0
+  , cardano-ledger-mary ==1.11.0.0
+  , cardano-ledger-shelley ==1.19.0.0
   , cardano-ledger-shelley-ma-test ==1.4.0.2
-  , cardano-protocol-tpraos ==1.5.0.0
+  , cardano-protocol-tpraos ==1.6.0.0
   , cardano-slotting ==0.2.1.0
   , cardano-strict-containers ==0.1.6.0
   , openapi3 >= 3.2.0
-  , ouroboros-consensus ==3.0.1.0
+  , ouroboros-consensus ==4.1.0.0
 
 package cardano-coin-selection
   tests: False

--- a/cardano-balance-tx.cabal
+++ b/cardano-balance-tx.cabal
@@ -67,19 +67,19 @@ library
     , bytestring                 >=0.10.6   && <0.13
     , cardano-addresses          >=4.0.2    && <4.1
     , cardano-coin-selection
-    , cardano-crypto-class
-    , cardano-ledger-allegra
-    , cardano-ledger-alonzo
-    , cardano-ledger-api
-    , cardano-ledger-babbage
-    , cardano-ledger-binary
-    , cardano-ledger-conway
-    , cardano-ledger-core
-    , cardano-ledger-dijkstra
-    , cardano-ledger-mary
-    , cardano-ledger-shelley
-    , cardano-protocol-tpraos    >=1.5.0.0  && <1.6
-    , cardano-slotting
+    , cardano-crypto-class       >=2.5.1.0  && <2.6
+    , cardano-ledger-allegra     >=1.10.0.0 && <1.11
+    , cardano-ledger-alonzo      >=1.16.0.0 && <1.17
+    , cardano-ledger-api         >=1.14.0.0 && <1.15
+    , cardano-ledger-babbage     >=1.14.0.0 && <1.15
+    , cardano-ledger-binary      >=1.9.0.0  && <1.10
+    , cardano-ledger-conway      >=1.23.0.0 && <1.24
+    , cardano-ledger-core        >=1.21.0.0 && <1.22
+    , cardano-ledger-dijkstra    >=0.3.0.0  && <0.4
+    , cardano-ledger-mary        >=1.11.0.0 && <1.12
+    , cardano-ledger-shelley     >=1.19.0.0 && <1.20
+    , cardano-protocol-tpraos    >=1.6.0.0  && <1.7
+    , cardano-slotting           >=0.2.1.0  && <0.3
     , cardano-strict-containers  >=0.1.6.0  && <0.2
     , cborg                      >=0.2.1    && <0.3
     , containers                 >=0.5      && <0.8
@@ -92,7 +92,7 @@ library
     , MonadRandom                >=0.6      && <0.7
     , monoid-subclasses          >=1.2.5.1  && <1.3
     , nonempty-containers        >=0.3.4.5  && <0.4
-    , ouroboros-consensus
+    , ouroboros-consensus        >=4.1.0.0  && <4.2
     , pretty-simple              >=4.1.2.0  && <4.2
     , QuickCheck                 >=2.14     && <2.16.0
     , serialise                  >=0.2.6.1  && <0.3

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1777742585,
-        "narHash": "sha256-ZzXz2vOhqethlqPgBExPXEnKWvaTbidsIxh5MGv+pwE=",
+        "lastModified": 1786970582,
+        "narHash": "sha256-V1jy4O3CNrd8dPvK2/c79ok4jLO5GXetugI4nvgcq/A=",
         "owner": "intersectmbo",
         "repo": "cardano-haskell-packages",
-        "rev": "e8a483522ee73c8c9493ea6055553e5c2532e66b",
+        "rev": "c0770200fcaa899ecdef548183dfee78e17bfb57",
         "type": "github"
       },
       "original": {
@@ -157,11 +157,11 @@
     "hackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1776301467,
-        "narHash": "sha256-1dthf9sMMjfFCRXjkM1iftdtsx17O3H/o/JrChA7AP4=",
+        "lastModified": 1786724927,
+        "narHash": "sha256-JnMzlMWyqWosnGpWHur5iiQFwHSxUYpHN13y4ONLGuM=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "055728d28f056b4f277f1b2d6e217afda0c8208a",
+        "rev": "1d6c4337df9348ef6a1c21f7dfd47e9b9a454ccf",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -35,7 +35,7 @@
           inherit system;
         };
         project = import ./nix/project.nix {
-          indexState = "2026-03-26T20:21:33Z";
+          indexState = "2026-08-14T13:38:07Z";
           inherit pkgs CHaP;
           mkdocs = mkdocs.packages.${system};
         };

--- a/lib/Cardano/Balance/Tx/Balance.hs
+++ b/lib/Cardano/Balance/Tx/Balance.hs
@@ -258,10 +258,10 @@ import GHC.Generics
 import Numeric.Natural
     ( Natural
     )
+import Prelude
 import Text.Pretty.Simple
     ( pShow
     )
-import Prelude
 
 import qualified Cardano.Address.KeyHash as CA
 import qualified Cardano.Address.Script as CA
@@ -438,10 +438,10 @@ instance (IsRecentEra era) => Buildable (PartialTx era) where
                     (blockListF' "-" inF (Map.toList (unUTxO extraUTxO)))
                 , nameF "redeemers" (pretty redeemers)
                 , nameF "tx" (txF tx)
-                , nameF "intended timelock key witness counts" $
-                    blockListF' "-" (build . show) $
-                        Map.toList $
-                            getTimelockKeyWitnessCounts timelockKeyWitnessCounts
+                , nameF "intended timelock key witness counts"
+                    $ blockListF' "-" (build . show)
+                    $ Map.toList
+                    $ getTimelockKeyWitnessCounts timelockKeyWitnessCounts
                 ]
       where
         inF = build . show
@@ -503,10 +503,10 @@ constructUTxOIndex availableUTxO =
     UTxOIndex{availableUTxO, availableUTxOIndex}
   where
     availableUTxOIndex =
-        UTxOIndex.fromMap $
-            Map.map toCSTokenBundle $
-                toInternalUTxOMap $
-                    toWalletUTxO availableUTxO
+        UTxOIndex.fromMap
+            $ Map.map toCSTokenBundle
+            $ toInternalUTxOMap
+            $ toWalletUTxO availableUTxO
 
 fromWalletUTxO
     :: forall era
@@ -873,12 +873,12 @@ balanceTxInner
                     | c >= 0 ->
                         pure $ W.Coin.unsafeFromIntegral c
                     | otherwise ->
-                        throwE $
-                            ErrBalanceTxInternalError $
-                                ErrUnderestimatedFee
-                                    (Coin (-c))
-                                    candidateTx
-                                    witCount
+                        throwE
+                            $ ErrBalanceTxInternalError
+                            $ ErrUnderestimatedFee
+                                (Coin (-c))
+                                candidateTx
+                                witCount
 
             let feeAndChange =
                     TxFeeAndChange
@@ -931,9 +931,9 @@ balanceTxInner
             if bal == mempty
                 then pure tx
                 else
-                    throwE $
-                        ErrBalanceTxInternalError $
-                            ErrFailedBalancing bal
+                    throwE
+                        $ ErrBalanceTxInternalError
+                        $ ErrFailedBalancing bal
 
         txBalance :: Tx era -> Value
         txBalance =
@@ -1358,9 +1358,9 @@ updateTx tx extraContent = do
     toLedgerScript s = \case
         RecentEraConway -> NativeScript $ Convert.toLedgerTimelockScript s
         RecentEraDijkstra ->
-            NativeScript $
-                DijkstraScripts.upgradeTimelock $
-                    Convert.toLedgerTimelockScript s
+            NativeScript
+                $ DijkstraScripts.upgradeTimelock
+                $ Convert.toLedgerTimelockScript s
 
 modifyShelleyTxBody
     :: forall era

--- a/lib/Cardano/Balance/Tx/Eras.hs
+++ b/lib/Cardano/Balance/Tx/Eras.hs
@@ -45,7 +45,8 @@ import Cardano.Ledger.Alonzo.TxWits
     ( AlonzoTxWits
     )
 import Cardano.Ledger.Alonzo.UTxO
-    ( AlonzoScriptsNeeded
+    ( AlonzoEraUTxO
+    , AlonzoScriptsNeeded
     )
 import Cardano.Ledger.Api
     ( ConwayEra
@@ -196,6 +197,7 @@ type RecentEraConstraints era =
     , Babbage.BabbageEraTxBody era
     , Alonzo.AlonzoEraTxBody era
     , Shelley.EraUTxO era
+    , AlonzoEraUTxO era
     , Core.EraTxCert era
     , Show (Core.TxOut era)
     , Show (Core.PParams era)

--- a/lib/Cardano/Balance/Tx/Gen.hs
+++ b/lib/Cardano/Balance/Tx/Gen.hs
@@ -79,6 +79,7 @@ import Data.Maybe
 import Data.Ratio
     ( (%)
     )
+import Prelude
 import Test.QuickCheck
     ( Gen
     , arbitrary
@@ -87,7 +88,6 @@ import Test.QuickCheck
 import Unsafe.Coerce
     ( unsafeCoerce
     )
-import Prelude
 
 import qualified Data.ByteString as BS
 import qualified Data.Map as Map

--- a/lib/Cardano/Balance/Tx/Primitive/Convert.hs
+++ b/lib/Cardano/Balance/Tx/Primitive/Convert.hs
@@ -180,9 +180,9 @@ fromLedgerTokenBundle (MaryValue ledgerAda (MultiAsset ledgerTokens)) =
     TokenBundle (fromLedgerCoin ledgerAda) walletTokenMap
   where
     walletTokenMap =
-        CS.TokenMap.fromFlatList $
-            concatMap expandPolicy $
-                Map.toList ledgerTokens
+        CS.TokenMap.fromFlatList
+            $ concatMap expandPolicy
+            $ Map.toList ledgerTokens
 
     expandPolicy
         :: (Ledger.PolicyID, Map.Map Ledger.AssetName Integer)
@@ -210,10 +210,10 @@ toLedgerTxIn (W.TxIn tid ix) =
     Ledger.TxIn (toLedgerTxId tid) (toEnum $ intCast ix)
   where
     toLedgerTxId h =
-        Ledger.TxId $
-            Hashes.unsafeMakeSafeHash $
-                Crypto.UnsafeHash $
-                    SBS.toShort h
+        Ledger.TxId
+            $ Hashes.unsafeMakeSafeHash
+            $ Crypto.UnsafeHash
+            $ SBS.toShort h
 
 -- | Convert from a ledger 'TxIn'.
 fromLedgerTxIn :: Ledger.TxIn -> W.TxIn
@@ -293,30 +293,30 @@ fromDijkstraTxOut (BabbageTxOut addr val _ _) =
 -- | Convert to a Conway-era ledger 'UTxO'.
 toLedgerUTxOConway :: W.UTxO -> UTxO ConwayEra
 toLedgerUTxOConway (W.UTxO m) =
-    UTxO $
-        Map.mapKeys toLedgerTxIn $
-            Map.map toConwayTxOut m
+    UTxO
+        $ Map.mapKeys toLedgerTxIn
+        $ Map.map toConwayTxOut m
 
 -- | Convert to a Dijkstra-era ledger 'UTxO'.
 toLedgerUTxODijkstra :: W.UTxO -> UTxO DijkstraEra
 toLedgerUTxODijkstra (W.UTxO m) =
-    UTxO $
-        Map.mapKeys toLedgerTxIn $
-            Map.map toDijkstraTxOut m
+    UTxO
+        $ Map.mapKeys toLedgerTxIn
+        $ Map.map toDijkstraTxOut m
 
 -- | Convert from a Conway-era ledger 'UTxO'.
 fromLedgerUTxOConway :: UTxO ConwayEra -> W.UTxO
 fromLedgerUTxOConway (UTxO m) =
-    W.UTxO $
-        Map.mapKeys fromLedgerTxIn $
-            Map.map fromConwayTxOut m
+    W.UTxO
+        $ Map.mapKeys fromLedgerTxIn
+        $ Map.map fromConwayTxOut m
 
 -- | Convert from a Dijkstra-era ledger 'UTxO'.
 fromLedgerUTxODijkstra :: UTxO DijkstraEra -> W.UTxO
 fromLedgerUTxODijkstra (UTxO m) =
-    W.UTxO $
-        Map.mapKeys fromLedgerTxIn $
-            Map.map fromDijkstraTxOut m
+    W.UTxO
+        $ Map.mapKeys fromLedgerTxIn
+        $ Map.map fromDijkstraTxOut m
 
 --------------------------------------------------------------------------------
 -- PolicyId / AssetName
@@ -364,13 +364,13 @@ toLedgerTimelockScript = \case
             Nothing ->
                 error "toLedgerTimelockScript: invalid key hash"
     CA.RequireAllOf contents ->
-        Scripts.mkRequireAllOfTimelock $
-            StrictSeq.fromList $
-                map toLedgerTimelockScript contents
+        Scripts.mkRequireAllOfTimelock
+            $ StrictSeq.fromList
+            $ map toLedgerTimelockScript contents
     CA.RequireAnyOf contents ->
-        Scripts.mkRequireAnyOfTimelock $
-            StrictSeq.fromList $
-                map toLedgerTimelockScript contents
+        Scripts.mkRequireAnyOfTimelock
+            $ StrictSeq.fromList
+            $ map toLedgerTimelockScript contents
     CA.RequireSomeOf num contents ->
         Scripts.mkRequireMOfTimelock
             (intCast num)
@@ -407,17 +407,17 @@ toWalletScript tokeyrole tl
         let payload = Crypto.hashToBytes h
         in  CA.RequireSignatureOf (CA.KeyHash (tokeyrole payload) payload)
     | Just contents <- Scripts.getRequireAllOfTimelock tl =
-        CA.RequireAllOf $
-            map (toWalletScript tokeyrole) $
-                F.toList contents
+        CA.RequireAllOf
+            $ map (toWalletScript tokeyrole)
+            $ F.toList contents
     | Just contents <- Scripts.getRequireAnyOfTimelock tl =
-        CA.RequireAnyOf $
-            map (toWalletScript tokeyrole) $
-                F.toList contents
+        CA.RequireAnyOf
+            $ map (toWalletScript tokeyrole)
+            $ F.toList contents
     | Just (num, contents) <- Scripts.getRequireMOfTimelock tl =
-        CA.RequireSomeOf (fromIntegral num) $
-            map (toWalletScript tokeyrole) $
-                F.toList contents
+        CA.RequireSomeOf (fromIntegral num)
+            $ map (toWalletScript tokeyrole)
+            $ F.toList contents
     | Scripts.RequireTimeExpire (SlotNo slot) <- tl =
         CA.ActiveUntilSlot $ fromIntegral slot
     | Scripts.RequireTimeStart (SlotNo slot) <- tl =

--- a/lib/Cardano/Balance/Tx/Primitive/Gen.hs
+++ b/lib/Cardano/Balance/Tx/Primitive/Gen.hs
@@ -78,6 +78,7 @@ import Data.Word
 import Numeric.Natural
     ( Natural
     )
+import Prelude
 import Test.QuickCheck
     ( Gen
     , arbitrary
@@ -91,7 +92,6 @@ import Test.QuickCheck
     , sized
     , vectorOf
     )
-import Prelude
 
 import qualified Cardano.Balance.Tx.Primitive as W
 import qualified Data.ByteString as BS

--- a/lib/Cardano/Balance/Tx/Redeemers.hs
+++ b/lib/Cardano/Balance/Tx/Redeemers.hs
@@ -278,9 +278,9 @@ assignScriptRedeemers pparams timeTranslation utxo redeemers tx = do
             , Set.null langViews =
                 SNothing
             | otherwise =
-                SJust $
-                    Alonzo.hashScriptIntegrity $
-                        Alonzo.ScriptIntegrity rdmrs dats langViews
+                SJust
+                    $ Alonzo.hashScriptIntegrity
+                    $ Alonzo.ScriptIntegrity rdmrs dats langViews
 
 --
 -- The 'Redeemer' type
@@ -344,8 +344,8 @@ mkRewardingPurpose
     => AsItem Word32 RewardAccount
     -> Alonzo.PlutusPurpose AsItem era
 mkRewardingPurpose = case recentEra @era of
-    RecentEraConway -> Conway.ConwayRewarding
-    RecentEraDijkstra -> Dijkstra.DijkstraRewarding
+    RecentEraConway -> Conway.ConwayWithdrawing
+    RecentEraDijkstra -> Dijkstra.DijkstraWithdrawing
 
 --------------------------------------------------------------------------------
 -- Utils

--- a/lib/Cardano/Balance/Tx/Sign.hs
+++ b/lib/Cardano/Balance/Tx/Sign.hs
@@ -204,19 +204,19 @@ estimateKeyWitnessCounts utxo tx timelockKeyWitCounts =
     Withdrawals wdrlMap =
         txBody ^. withdrawalsTxBodyL
     nKeyWithdrawals =
-        length $
-            filter isKeyHashWithdrawal $
-                Map.keys wdrlMap
+        length
+            $ filter isKeyHashWithdrawal
+            $ Map.keys wdrlMap
     certs = F.toList (txBody ^. certsTxBodyL)
     nCertWits =
         sumVia estimateDelegSigningKeys certs
     nonInputWits =
-        numberOfShelleyWitnesses $
-            fromIntegral $
-                nExtraKeyWits
-                    + nKeyWithdrawals
-                    + fromIntegral nCertWits
-                    + fromIntegral timelockTotalWitCount
+        numberOfShelleyWitnesses
+            $ fromIntegral
+            $ nExtraKeyWits
+                + nKeyWithdrawals
+                + fromIntegral nCertWits
+                + fromIntegral timelockTotalWitCount
     inputWits =
         KeyWitnessCounts
             { nKeyWits =
@@ -239,19 +239,19 @@ estimateKeyWitnessCounts utxo tx timelockKeyWitCounts =
 
     timelockTotalWitCount :: Natural
     timelockTotalWitCount =
-        sum $
-            Map.elems $
-                Map.unionWith
-                    (\_est spec -> spec) -- Allow specified values to override
-                    upperBoundEstimatedTimelockKeyWitnessCounts
-                    specifiedTimelockKeyWitnessCounts
+        sum
+            $ Map.elems
+            $ Map.unionWith
+                (\_est spec -> spec) -- Allow specified values to override
+                upperBoundEstimatedTimelockKeyWitnessCounts
+                specifiedTimelockKeyWitnessCounts
       where
         specifiedTimelockKeyWitnessCounts
             :: Map (ScriptHash) Natural
         specifiedTimelockKeyWitnessCounts =
-            Map.fromList $
-                mapMaybe resolve $
-                    F.toList scriptsNeeded
+            Map.fromList
+                $ mapMaybe resolve
+                $ F.toList scriptsNeeded
           where
             resolve
                 :: (ScriptHash)
@@ -278,9 +278,9 @@ estimateKeyWitnessCounts utxo tx timelockKeyWitCounts =
 
         scriptsNeeded :: Set (ScriptHash)
         scriptsNeeded =
-            getScriptsHashesNeeded $
-                getScriptsNeeded utxo $
-                    view bodyTxL tx
+            getScriptsHashesNeeded
+                $ getScriptsNeeded utxo
+                $ view bodyTxL tx
 
         scriptsAvailableInBody :: Map (ScriptHash) (Script era)
         scriptsAvailableInBody = tx ^. witsTxL . scriptTxWitsL

--- a/lib/Cardano/Balance/Tx/Tx.hs
+++ b/lib/Cardano/Balance/Tx/Tx.hs
@@ -158,9 +158,6 @@ import Cardano.Ledger.Coin
 import Cardano.Ledger.Compactible
     ( fromCompact
     )
-import Cardano.Ledger.Conway.PParams
-    ( ppDRepDepositL
-    )
 import Cardano.Ledger.Conway.Scripts
     ( PlutusScript (..)
     )
@@ -516,9 +513,9 @@ forceUTxOToEra
     => UTxO era1
     -> Either ErrInvalidTxOutInEra (UTxO era2)
 forceUTxOToEra (UTxO utxo) =
-    utxoFromTxOutsInRecentEra $
-        map (second wrapTxOutInRecentEra) $
-            Map.toList utxo
+    utxoFromTxOutsInRecentEra
+        $ map (second wrapTxOutInRecentEra)
+        $ Map.toList utxo
 
 --------------------------------------------------------------------------------
 -- Tx
@@ -650,18 +647,8 @@ evaluateTransactionBalance pp depositLookup =
     Ledger.evalBalanceTxBody
         pp
         depositLookup
-        dRepDepositAssumeCurrent
         assumePoolIsReg
   where
-    -- Deposit lookup for `UnRegDRep` certificates in the TxBody
-    --
-    -- TODO [ADP-3404] Query actual value of deposit
-    --
-    -- https://cardanofoundation.atlassian.net/browse/ADP-3404
-    dRepDepositAssumeCurrent _drepCred = case recentEra @era of
-        RecentEraConway -> Just $ pp ^. ppDRepDepositL
-        RecentEraDijkstra -> Just $ pp ^. ppDRepDepositL
-
     -- Checks whether a pool with a supplied 'PoolStakeId' is already
     -- registered.
     --

--- a/lib/Cardano/Balance/Tx/TxWithUTxO/Gen.hs
+++ b/lib/Cardano/Balance/Tx/TxWithUTxO/Gen.hs
@@ -49,6 +49,7 @@ import Control.Monad
 import Data.List
     ( transpose
     )
+import Prelude
 import Test.QuickCheck
     ( Gen
     , Positive (..)
@@ -56,7 +57,6 @@ import Test.QuickCheck
     , frequency
     , suchThat
     )
-import Prelude
 
 import qualified Cardano.Balance.Tx.TxWithUTxO as TxWithUTxO
 import qualified Data.Map.Strict as Map

--- a/specs/45-node-11-1-0/data-model.md
+++ b/specs/45-node-11-1-0/data-model.md
@@ -1,0 +1,8 @@
+# Data model — cardano-balance-transaction#45
+
+No new types.
+
+Dijkstra era remains implemented (`RecentEraDijkstra`). If 0.3.0.0
+adds required fields whose values would have to be invented, that
+is HS-DESIGN: stop and Q. A renamed constructor with a 1:1
+replacement is mechanical.

--- a/specs/45-node-11-1-0/functions-model.md
+++ b/specs/45-node-11-1-0/functions-model.md
@@ -1,0 +1,4 @@
+# Functions model — cardano-balance-transaction#45
+
+No new functions. Compiler-forced 1:1 renames in place.
+New exported names or invented arguments: HS-DESIGN.

--- a/specs/45-node-11-1-0/modules-model.md
+++ b/specs/45-node-11-1-0/modules-model.md
@@ -1,0 +1,12 @@
+# Modules model — cardano-balance-transaction#45
+
+No new modules. Existing owners stay.
+
+Likely mechanical touch: `lib/Cardano/Balance/Tx/Redeemers.hs`
+(`DijkstraSpending`/`Minting`/`Rewarding`), `Eras.hs` (`RecentEra
+Dijkstra`), and any file the compiler names for consensus 4 /
+crypto-class 2.5 / alonzo 1.16.
+
+#21 APIs `sizeSignKeyVRF`, `IsValid`, `TPraos.BHeader` are
+**absent** here (control: `Cardano.Crypto.Hash` is present). Do not
+edit files to "apply" those adaptations without a compiler error.

--- a/specs/45-node-11-1-0/plan.md
+++ b/specs/45-node-11-1-0/plan.md
@@ -35,4 +35,6 @@ found.
 Forbidden: extra constraint members, invented versions, SRP bump,
 tracked gitignore harness paths, other repos, GPG, push.
 
-Build: repo `nix develop`, not a bare `nix shell`.
+Build: this repo's CI (`just build` / `just unit` = `nix build` /
+`nix run` of flake packages). Not a bare `nix shell`. cabal-in-shell
+is not the gate (Q1).

--- a/specs/45-node-11-1-0/plan.md
+++ b/specs/45-node-11-1-0/plan.md
@@ -1,0 +1,38 @@
+# Plan — cardano-balance-transaction#45
+
+One OWNER slice. LIGHT ineligible: dijkstra 0.3.0.0 and two majors.
+
+## Topology (exceptions, not precedent)
+
+- TO: grok pane `%124` (`context=REUSED` from clr21)
+- CO: `qwen --yolo --model qwen3.8-max-preview` `draft=NONE`
+- Auditor: `claude --dangerously-skip-permissions --model sonnet --effort high`
+- Push/PR: parent `%121`. Local `git -c commit.gpgsign=false`.
+
+## cardano-deps mapping
+
+s4 CHaP → `c0770200…`. s5 freeze already produced. s6 bounds.
+s7 cabal.project. s8 N/A. Nix `indexState` + likely hackage snapshot
+(`#21` Cabal-7159). No `cardano-lmdb` override here (control:
+`nix/project.nix` has only crypto-praos/crypto-class pkgconfig).
+Leave those and do not invent an lmdb deletion.
+
+## Slice S1
+
+Base: `6875d5b9702bcc0c4b4ebfffda118a705e70feed`.
+Branch: `chore/issue-45-node-11-1-0`.
+Worktree: this clone. Never `/code/cardano-balance-transaction`
+or `/code/cardano-wallet`.
+
+Owned: `cabal.project` (index-states + freeze constraint members +
+solved `-test` pins), `cardano-balance-tx.cabal` bounds,
+`flake.nix` indexState, `flake.lock` (CHaP + hackage snapshot as
+#21), `nix/project.nix` only if eval rejects a stale
+`packages.*` override, `lib/**/*.hs` `test/**/*.hs` compiler-forced,
+one existing-suite assertion if an unpinned adaptation value is
+found.
+
+Forbidden: extra constraint members, invented versions, SRP bump,
+tracked gitignore harness paths, other repos, GPG, push.
+
+Build: repo `nix develop`, not a bare `nix shell`.

--- a/specs/45-node-11-1-0/plan.md
+++ b/specs/45-node-11-1-0/plan.md
@@ -38,3 +38,27 @@ tracked gitignore harness paths, other repos, GPG, push.
 Build: this repo's CI (`just build` / `just unit` = `nix build` /
 `nix run` of flake packages). Not a bare `nix shell`. cabal-in-shell
 is not the gate (Q1).
+
+## Gate v3 (post-push correction, ticket-owner ruling)
+
+CI failed `Fourmolu` on PR #46 after push: gate v2's fourmolu/hlint step
+was scoped to `git diff --diff-filter=ACMR <base> -- '*.hs'` (only files
+this slice touched), while CI's own `.github/workflows/ci.yml` runs
+`fourmolu -m check lib test` / `hlint lib test` over the **whole tree**.
+This slice's own T004 flake.lock haskellNix/hackage-snapshot bump moves
+the fourmolu version the dev shell and CI both resolve (now 0.20.1.0),
+so 17 files this slice never touched newly disagreed with the new
+toolchain's layout opinion — a real CI failure the diff-filtered gate
+structurally could not see. `main` at this branch's base was itself
+CI-green (run 28228668216, 2026-06-26): not a pre-existing repo issue.
+
+Gate v3 replaces the diff-filtered fourmolu/hlint step with the exact
+whole-tree commands CI runs (`fourmolu -m check lib test`, `hlint lib
+test`, plus `nixfmt --check flake.nix nix/*.nix` for completeness).
+Negative control: v3's fourmolu step exits 100 against the pre-fix tree
+(captured before the fix, 17-file diff). Fix: `fourmolu -i lib test`,
+layout-only (insertions == deletions in every file) — kept as its own
+commit (`style: fourmolu 0.20.1.0 whole-tree reformat`) stacked right
+after the pin-set commit, rather than folded into it, so the pin-set
+diff stays reviewable on its own. v3 hash:
+`bde57aa638987b0523a376fe3e0b059df5670cde4e2cbf8bbc501da8a5351908`.

--- a/specs/45-node-11-1-0/spec.md
+++ b/specs/45-node-11-1-0/spec.md
@@ -55,10 +55,13 @@ Issue: https://github.com/cardano-foundation/cardano-balance-transaction/issues/
   `haskellNix/hackage` to
   `1d6c4337df9348ef6a1c21f7dfd47e9b9a454ccf` (node 11.1.0). Do not
   bump `haskellNix` itself unless that fails (then Q).
-- **FR-BUILD.** Repo own `nix develop --quiet --accept-flake-config
-  --no-write-lock-file -c cabal build all --enable-tests -O0`.
-- **FR-TEST.** Same shell, `cabal test unit --enable-tests -O0`.
-  Failures recorded with cause.
+- **FR-BUILD.** This repo's CI path (Q1): `nix build --accept-flake-config
+  --allow-import-from-derivation --quiet --no-write-lock-file .#lib .#unit-tests`.
+  (`just build`.) cabal-in-shell is unsatisfiable here against haskell.nix
+  installed `:testlib` units; that is pre-existing, not a pin-set defect.
+- **FR-TEST.** `nix run --accept-flake-config --allow-import-from-derivation
+  --quiet --no-write-lock-file .#unit-tests` (`just unit`). Failures recorded
+  with cause.
 - **FR-ADAPT.** Mechanical only. Same five #21 adaptations if this
   tree uses those APIs. Hunt unpinned values the adaptation
   changes; if old==new, one assertion proven able to fail; if

--- a/specs/45-node-11-1-0/spec.md
+++ b/specs/45-node-11-1-0/spec.md
@@ -1,0 +1,100 @@
+# Spec — cardano-balance-transaction#45
+
+Move this repository's hardcoded pin set from `cardano-node`
+11.0.1 to 11.1.0. Freeze sha256
+`6a636c62ed1793c8dc8157633e1a907300efebdf9e98c4708cc8cbf8f317bab4`,
+570 lines. Resolver output. Do not improve from bounds.
+
+Issue: https://github.com/cardano-foundation/cardano-balance-transaction/issues/45
+
+## Functional requirements
+
+- **FR-INDEX.** Both `cabal.project` index-state occurrences:
+  hackage `2026-08-14T13:38:07Z`, CHaP `2026-08-17T11:39:16Z`.
+- **FR-CONSTRAINTS.** Freeze-pinned members become:
+
+  | package | pin |
+  |---|---|
+  | cardano-addresses | `==4.0.2` (unchanged) |
+  | cardano-binary | `==1.9.1.0` |
+  | cardano-crypto-class | `==2.5.1.0` |
+  | cardano-crypto-wrapper | `==1.7.0.0` (unchanged) |
+  | cardano-ledger-allegra | `==1.10.0.0` |
+  | cardano-ledger-alonzo | `==1.16.0.0` |
+  | cardano-ledger-api | `==1.14.0.0` |
+  | cardano-ledger-babbage | `==1.14.0.0` |
+  | cardano-ledger-binary | `==1.9.0.0` |
+  | cardano-ledger-byron | `==1.3.0.0` (unchanged) |
+  | cardano-ledger-conway | `==1.23.0.0` |
+  | cardano-ledger-core | `==1.21.0.0` |
+  | cardano-ledger-dijkstra | `==0.3.0.0` |
+  | cardano-ledger-mary | `==1.11.0.0` |
+  | cardano-ledger-shelley | `==1.19.0.0` |
+  | cardano-protocol-tpraos | `==1.6.0.0` |
+  | cardano-slotting | `==0.2.1.0` (unchanged) |
+  | cardano-strict-containers | `==0.1.6.0` (unchanged) |
+  | ouroboros-consensus | `==4.1.0.0` |
+
+  Leave `base >= 4.18.2.0 && < 5` and `openapi3 >= 3.2.0`.
+  Leave `allow-newer` and the coin-selection SRP unless the solve
+  forces a report (do not bump the SRP in this ticket).
+
+- **FR-TEST-PINS.** `cardano-ledger-alonzo-test` and
+  `cardano-ledger-shelley-ma-test` are **not in the node freeze**
+  (control: freeze has `cardano-ledger-core ==1.21.0.0`; those two
+  names are absent). Resolve them at the new index-state and keep
+  `==` pins. Record the landed versions in the receipt.
+- **FR-BOUNDS.** Library `build-depends` freeze-pinned packages:
+  lower = freeze version, upper = next minor (`cardano-deps` §6).
+- **FR-CHAP.** `flake.lock` CHaP rev
+  `c0770200fcaa899ecdef548183dfee78e17bfb57`.
+- **FR-NIX-INDEX.** `flake.nix` `indexState` =
+  `2026-08-14T13:38:07Z`.
+- **FR-HACKAGE.** If haskell.nix plan-to-nix Cabal-7159s because
+  hackage.nix is older than the index-state, bump **only**
+  `haskellNix/hackage` to
+  `1d6c4337df9348ef6a1c21f7dfd47e9b9a454ccf` (node 11.1.0). Do not
+  bump `haskellNix` itself unless that fails (then Q).
+- **FR-BUILD.** Repo own `nix develop --quiet --accept-flake-config
+  --no-write-lock-file -c cabal build all --enable-tests -O0`.
+- **FR-TEST.** Same shell, `cabal test unit --enable-tests -O0`.
+  Failures recorded with cause.
+- **FR-ADAPT.** Mechanical only. Same five #21 adaptations if this
+  tree uses those APIs. Hunt unpinned values the adaptation
+  changes; if old==new, one assertion proven able to fail; if
+  different, HS-BEHAVIOUR.
+- **FR-DIJKSTRA.** Any `cardano-ledger-dijkstra` 0.3.0.0 surface
+  change is reported explicitly (constructors
+  `DijkstraSpending`/`DijkstraMinting`/`DijkstraRewarding` in
+  `Redeemers.hs`, `RecentEra Dijkstra` in `Eras.hs`).
+- **FR-COINSEL.** `cardano-coin-selection` at
+  `176611048d5b9f33df19d106cd925d63a7858bb2` stays. Confirmed: its
+  `cabal.project` has no ecosystem constraints; its `.cabal` has no
+  cardano-ledger/ouroboros depends. If the solve proves otherwise,
+  report, do not bump it here.
+
+## Hard stops
+
+HS-DESIGN (most likely dijkstra 0.3.0.0), HS-BEHAVIOUR, HS-OUTSIDE,
+or old-vs-new value differs: file Q and park.
+
+## Invariants
+
+| ID | Severity | Observable |
+|---|---|---|
+| INV-45-INDEX-STATE | BLOCKING | FR-INDEX |
+| INV-45-CONSTRAINTS | BLOCKING | freeze-pinned == pins as table |
+| INV-45-TEST-PINS | BLOCKING | two `-test` packages still `==` pinned; versions recorded |
+| INV-45-BOUNDS | BLOCKING | FR-BOUNDS |
+| INV-45-CHAP | BLOCKING | FR-CHAP |
+| INV-45-NIX-INDEX | BLOCKING | FR-NIX-INDEX |
+| INV-45-BUILD | BLOCKING | FR-BUILD |
+| INV-45-TEST | BLOCKING | FR-TEST |
+| INV-45-ADAPT-MECHANICAL | BLOCKING | mechanical only; unpinned seed-like values hunted |
+| INV-45-NO-OUTSIDE | BLOCKING | this clone only |
+| INV-45-OLD-PINS-GONE | BLOCKING | `ouroboros-consensus ==3.0.1.0`, `cardano-crypto-class ==2.3.2.0`, `2026-03-26T20:21:33Z` absent |
+| INV-45-DIJKSTRA-REPORT | BLOCKING | 0.3.0.0 surface delta named in receipt, or "unchanged" with a control |
+
+Auditor: sanity only. No mutation campaign. No new suites except
+the one seed-size-like pin if found. No tracked `.gitignore` for
+`/gate.sh` or `.orch/`.

--- a/specs/45-node-11-1-0/tasks.md
+++ b/specs/45-node-11-1-0/tasks.md
@@ -14,6 +14,6 @@ Slice **S1** (OWNER).
 - [ ] **T005** Mechanical Haskell adaptation. Report dijkstra
       0.3.0.0 surface. Hunt unpinned seed-like values.
 - [ ] **T006** fourmolu + hlint on touched Haskell.
-- [ ] **T007** `nix develop` `cabal build all --enable-tests -O0`
-      and `cabal test unit --enable-tests -O0`. Confirm
-      coin-selection SRP needs no bump (or report).
+- [ ] **T007** `nix build .#lib .#unit-tests` and
+      `nix run .#unit-tests` (Q1). Confirm coin-selection SRP needs
+      no bump (or report).

--- a/specs/45-node-11-1-0/tasks.md
+++ b/specs/45-node-11-1-0/tasks.md
@@ -1,0 +1,19 @@
+# Tasks — cardano-balance-transaction#45
+
+Slice **S1** (OWNER).
+
+- [ ] **T001** `cabal.project` index-states + freeze constraint
+      table. Old 11.0.1 values gone. `allow-newer` untouched unless
+      the solver requires a recorded exception.
+- [ ] **T002** Resolve and pin `cardano-ledger-alonzo-test` and
+      `cardano-ledger-shelley-ma-test` at the new index-state.
+      Record landed versions.
+- [ ] **T003** `.cabal` freeze-lower / next-minor-upper.
+- [ ] **T004** `flake.nix` indexState; `flake.lock` CHaP
+      `c0770200…`; hackage snapshot `1d6c4337…` if Cabal-7159.
+- [ ] **T005** Mechanical Haskell adaptation. Report dijkstra
+      0.3.0.0 surface. Hunt unpinned seed-like values.
+- [ ] **T006** fourmolu + hlint on touched Haskell.
+- [ ] **T007** `nix develop` `cabal build all --enable-tests -O0`
+      and `cabal test unit --enable-tests -O0`. Confirm
+      coin-selection SRP needs no bump (or report).

--- a/specs/45-node-11-1-0/tasks.md
+++ b/specs/45-node-11-1-0/tasks.md
@@ -2,18 +2,18 @@
 
 Slice **S1** (OWNER).
 
-- [ ] **T001** `cabal.project` index-states + freeze constraint
+- [x] **T001** `cabal.project` index-states + freeze constraint
       table. Old 11.0.1 values gone. `allow-newer` untouched unless
       the solver requires a recorded exception.
-- [ ] **T002** Resolve and pin `cardano-ledger-alonzo-test` and
+- [x] **T002** Resolve and pin `cardano-ledger-alonzo-test` and
       `cardano-ledger-shelley-ma-test` at the new index-state.
       Record landed versions.
-- [ ] **T003** `.cabal` freeze-lower / next-minor-upper.
-- [ ] **T004** `flake.nix` indexState; `flake.lock` CHaP
+- [x] **T003** `.cabal` freeze-lower / next-minor-upper.
+- [x] **T004** `flake.nix` indexState; `flake.lock` CHaP
       `c0770200…`; hackage snapshot `1d6c4337…` if Cabal-7159.
-- [ ] **T005** Mechanical Haskell adaptation. Report dijkstra
+- [x] **T005** Mechanical Haskell adaptation. Report dijkstra
       0.3.0.0 surface. Hunt unpinned seed-like values.
-- [ ] **T006** fourmolu + hlint on touched Haskell.
-- [ ] **T007** `nix build .#lib .#unit-tests` and
+- [x] **T006** fourmolu + hlint on touched Haskell.
+- [x] **T007** `nix build .#lib .#unit-tests` and
       `nix run .#unit-tests` (Q1). Confirm coin-selection SRP needs
       no bump (or report).

--- a/test/spec/Cardano/Balance/Tx/Balance/CoinSelectionSpec.hs
+++ b/test/spec/Cardano/Balance/Tx/Balance/CoinSelectionSpec.hs
@@ -21,6 +21,7 @@ import Generics.SOP
     ( NP (..)
     )
 import qualified Generics.SOP as SOP
+import Prelude
 import Test.Hspec
     ( Spec
     , describe
@@ -50,7 +51,6 @@ import Test.QuickCheck.Extra
 import Test.Utils.Pretty
     ( (====)
     )
-import Prelude
 
 import qualified Cardano.Balance.Tx.Primitive as W
 import qualified Cardano.Balance.Tx.Primitive.Gen as W

--- a/test/spec/Cardano/Balance/Tx/Balance/SurplusSpec.hs
+++ b/test/spec/Cardano/Balance/Tx/Balance/SurplusSpec.hs
@@ -37,6 +37,7 @@ import Data.Maybe
 import Data.Monoid.Monus
     ( Monus ((<\>))
     )
+import Prelude
 import Test.Hspec
     ( Spec
     , describe
@@ -67,7 +68,6 @@ import Test.QuickCheck.Extra
     ( report
     , shrinkNatural
     )
-import Prelude
 
 import qualified Cardano.Balance.Tx.Primitive as W
 import qualified Cardano.Balance.Tx.Primitive as W.Coin
@@ -175,13 +175,13 @@ spec = do
                 & property
 
     describe "distributeSurplusDelta" $ do
-        describe "when increasing change increases fee" $
-            it "will increase fee (99 lovelace for change, 1 for fee)" $
-                distributeSurplusDelta
-                    (FeePerByte 1)
-                    (W.Coin 100)
-                    (TxFeeAndChange (W.Coin 200) [W.Coin 200])
-                    `shouldBe` Right (TxFeeAndChange (W.Coin 1) [W.Coin 99])
+        describe "when increasing change increases fee"
+            $ it "will increase fee (99 lovelace for change, 1 for fee)"
+            $ distributeSurplusDelta
+                (FeePerByte 1)
+                (W.Coin 100)
+                (TxFeeAndChange (W.Coin 200) [W.Coin 200])
+                `shouldBe` Right (TxFeeAndChange (W.Coin 1) [W.Coin 99])
 
         describe "when increasing fee increases fee" $
             it "will increase fee (98 lovelace for change, 2 for fee)" $
@@ -372,11 +372,11 @@ prop_distributeSurplus_onSuccess_increasesValuesByDelta =
          (TxFeeAndChange feeOriginal changeOriginal)
          (TxFeeAndChange feeModified changeModified) ->
                 let (TxFeeAndChange feeDelta changeDeltas) =
-                        either (error . show) id $
-                            distributeSurplusDelta policy surplus $
-                                TxFeeAndChange
-                                    (feeOriginal)
-                                    (W.TxOut.coin <$> changeOriginal)
+                        either (error . show) id
+                            $ distributeSurplusDelta policy surplus
+                            $ TxFeeAndChange
+                                (feeOriginal)
+                                (W.TxOut.coin <$> changeOriginal)
                 in  ( TxFeeAndChange
                         (feeModified <\> feeDelta)
                         (zipWith W.TxOut.subtractCoin changeDeltas changeModified)

--- a/test/spec/Cardano/Balance/Tx/Balance/TokenBundleSizeSpec.hs
+++ b/test/spec/Cardano/Balance/Tx/Balance/TokenBundleSizeSpec.hs
@@ -47,6 +47,7 @@ import Data.Monoid.Monus
 import Data.Word
     ( Word32
     )
+import Prelude
 import Test.Hspec
     ( Spec
     , describe
@@ -67,7 +68,6 @@ import Test.QuickCheck
     , (===)
     , (==>)
     )
-import Prelude
 
 import qualified Cardano.Balance.Tx.Primitive as W
 import qualified Cardano.Balance.Tx.Primitive.Gen as W
@@ -140,13 +140,13 @@ unit_assessTokenBundleSize_fixedSizeBundle
     assessor
     expectedMinLengthBytes
     expectedMaxLengthBytes =
-        withMaxSuccess 100 $
-            counterexample counterexampleText $
-                conjoin . fmap property $
-                    [ actualAssessment == expectedAssessment
-                    , actualLengthBytes >= expectedMinLengthBytes
-                    , actualLengthBytes <= expectedMaxLengthBytes
-                    ]
+        withMaxSuccess 100
+            $ counterexample counterexampleText
+            $ conjoin . fmap property
+            $ [ actualAssessment == expectedAssessment
+              , actualLengthBytes >= expectedMinLengthBytes
+              , actualLengthBytes <= expectedMaxLengthBytes
+              ]
       where
         actualAssessment = assessWalletTokenBundleSize assessor bundle
         v = eraProtVerLow @Dijkstra

--- a/test/spec/Cardano/Balance/Tx/BalanceSpec.hs
+++ b/test/spec/Cardano/Balance/Tx/BalanceSpec.hs
@@ -320,6 +320,7 @@ import Ouroboros.Consensus.Config
 import Ouroboros.Consensus.HardFork.History
     ( PastHorizonException
     )
+import Prelude
 import System.Directory
     ( listDirectory
     )
@@ -410,7 +411,6 @@ import Test.Utils.Pretty
 import Text.Read
     ( readMaybe
     )
-import Prelude
 
 import qualified Cardano.Address as CA
 import qualified Cardano.Address.Derivation as CA
@@ -473,13 +473,13 @@ spec_balanceTx
     :: forall era. (TestRecentEra era) => RecentEra era -> Spec
 spec_balanceTx era = describe "balanceTx" $ do
     let moreDiscardsAllowed = stdArgs{maxDiscardRatio = 100}
-    it "doesn't balance transactions with existing 'totalCollateral'" $
-        quickCheckWith moreDiscardsAllowed $
-            prop_balanceTxExistingTotalCollateral era
+    it "doesn't balance transactions with existing 'totalCollateral'"
+        $ quickCheckWith moreDiscardsAllowed
+        $ prop_balanceTxExistingTotalCollateral era
 
-    it "doesn't balance transactions with existing 'returnCollateral'" $
-        quickCheckWith moreDiscardsAllowed $
-            prop_balanceTxExistingReturnCollateral era
+    it "doesn't balance transactions with existing 'returnCollateral'"
+        $ quickCheckWith moreDiscardsAllowed
+        $ prop_balanceTxExistingReturnCollateral era
 
     it "does not balance transactions if no inputs can be created" $
         property (prop_balanceTxUnableToCreateInput era)
@@ -506,13 +506,13 @@ spec_balanceTx era = describe "balanceTx" $ do
 
         let evaluateMinimumFeeSize :: Tx era -> Natural
             evaluateMinimumFeeSize tx =
-                fromIntegral $
-                    Write.unCoin $
-                        estimateSignedTxMinFee
-                            pp
-                            inputsHaveNoRefScripts
-                            (withNoKeyWits tx)
-                            (KeyWitnessCounts 0 (fromIntegral $ length wits))
+                fromIntegral
+                    $ Write.unCoin
+                    $ estimateSignedTxMinFee
+                        pp
+                        inputsHaveNoRefScripts
+                        (withNoKeyWits tx)
+                        (KeyWitnessCounts 0 (fromIntegral $ length wits))
               where
                 wits = tx ^. witsTxL . bootAddrTxWitsL
 
@@ -595,9 +595,9 @@ spec_balanceTx era = describe "balanceTx" $ do
         let nChange = max nPayments 1
         let changeState0 = DummyChangeState 0
         let expectedChange =
-                flip evalState changeState0 $
-                    replicateM nChange $
-                        state @Identity dummyChangeAddrGen.genChangeAddress
+                flip evalState changeState0
+                    $ replicateM nChange
+                    $ state @Identity dummyChangeAddrGen.genChangeAddress
 
         let
             address :: TxOut era -> Address
@@ -617,9 +617,9 @@ spec_balanceTx era = describe "balanceTx" $ do
         let (out :: TxOut era) = mkBasicTxOut dummyAddr (lovelace 0)
         let (out' :: TxOut era) = mkBasicTxOut dummyAddr (lovelace 866_310)
         let tx =
-                either (error . show) id $
-                    balance $
-                        paymentPartialTx [out]
+                either (error . show) id
+                    $ balance
+                    $ paymentPartialTx [out]
         let outs = F.toList $ tx ^. bodyTxL . outputsTxBodyL
 
         let pp = case era of
@@ -932,13 +932,13 @@ spec_balanceTx era = describe "balanceTx" $ do
     dustWallet = mkTestWallet dustUTxO
     dustUTxO :: UTxO era
     dustUTxO =
-        UTxO $
-            Map.fromList $
-                [ ( Convert.toLedgerTxIn $ W.TxIn (B8.replicate 32 '1') ix
-                  , mkBasicTxOut dummyAddr (ada 1)
-                  )
-                | ix <- [0 .. 500]
-                ]
+        UTxO
+            $ Map.fromList
+            $ [ ( Convert.toLedgerTxIn $ W.TxIn (B8.replicate 32 '1') ix
+                , mkBasicTxOut dummyAddr (ada 1)
+                )
+              | ix <- [0 .. 500]
+              ]
 
     balance =
         testBalanceTx
@@ -957,10 +957,10 @@ spec_balanceTx era = describe "balanceTx" $ do
     utxo coins = utxoWithValues $ map Value.inject coins
 
     dummyAddr =
-        Convert.toLedgerAddress $
-            W.Address $
-                unsafeFromHex
-                    "60b1e5e0fb74c86c801f646841e07cdb42df8b82ef3ce4e57cb5412e77"
+        Convert.toLedgerAddress
+            $ W.Address
+            $ unsafeFromHex
+                "60b1e5e0fb74c86c801f646841e07cdb42df8b82ef3ce4e57cb5412e77"
 
     totalOutput :: (TestRecentEra era) => Tx era -> Coin
     totalOutput tx =
@@ -1090,10 +1090,10 @@ balanceTxGoldenSpec era = describe "balance goldens" $ do
         dummyHash = B8.replicate 32 '0'
 
     addr =
-        Convert.toLedgerAddress $
-            W.Address $
-                unsafeFromHex
-                    "60b1e5e0fb74c86c801f646841e07cdb42df8b82ef3ce4e57cb5412e77"
+        Convert.toLedgerAddress
+            $ W.Address
+            $ unsafeFromHex
+                "60b1e5e0fb74c86c801f646841e07cdb42df8b82ef3ce4e57cb5412e77"
 
     payment :: PartialTx era
     payment =
@@ -1210,18 +1210,18 @@ _spec_estimateSignedTxSize _era = describe "estimateSignedTxSize" $ do
     -- An address with a vk payment credential. For the test above, this is the
     -- only aspect which matters.
     vkCredAddr =
-        Convert.toLedgerAddress $
-            W.Address $
-                unsafeFromHex
-                    "6000000000000000000000000000000000000000000000000000000000"
+        Convert.toLedgerAddress
+            $ W.Address
+            $ unsafeFromHex
+                "6000000000000000000000000000000000000000000000000000000000"
 
     -- This is a short bootstrap address retrieved from
     -- "byron-address-format.md".
     bootAddr =
-        Convert.toLedgerAddress $
-            W.Address $
-                unsafeFromHex
-                    "82d818582183581cba970ad36654d8dd8f74274b733452ddeab9a62a397746be3c42ccdda0001a9026da5b"
+        Convert.toLedgerAddress
+            $ W.Address
+            $ unsafeFromHex
+                "82d818582183581cba970ad36654d8dd8f74274b733452ddeab9a62a397746be3c42ccdda0001a9026da5b"
 
     -- With more attributes, the address can be longer. This value was chosen
     -- /experimentally/ to make the tests pass. The ledger has been validating
@@ -1604,8 +1604,20 @@ prop_balanceTxValid
             prop_dijkstraContextError = \case
                 DijkstraTxInfo.ConwayContextError e ->
                     prop_conwayContextError e
+                DijkstraTxInfo.SubTxContextError _ _ ->
+                    succeedWithLabel "SubTxContextError"
                 DijkstraTxInfo.PointerPresentInOutput _ ->
                     succeedWithLabel "PointerPresentInOutput"
+                DijkstraTxInfo.UnsupportedScriptInSubTx _ _ ->
+                    succeedWithLabel "UnsupportedScriptInSubTx"
+                DijkstraTxInfo.DirectDepositsNotSupported _ ->
+                    succeedWithLabel "DirectDepositsNotSupported"
+                DijkstraTxInfo.AccountBalanceIntervalsNotSupported _ ->
+                    succeedWithLabel "AccountBalanceIntervalsNotSupported"
+                DijkstraTxInfo.GuardScriptHashesNotSupported _ ->
+                    succeedWithLabel "GuardScriptHashesNotSupported"
+                DijkstraTxInfo.RequiredTopLevelGuardsNotSupported _ ->
+                    succeedWithLabel "RequiredTopLevelGuardsNotSupported"
 
             prop_conwayContextError :: ConwayContextError era -> Property
             prop_conwayContextError = \case
@@ -1704,10 +1716,10 @@ prop_balanceTxValid
           where
             valid :: TxOut era -> Property
             valid out =
-                counterexample msg $
-                    property $
-                        not $
-                            Write.isBelowMinimumCoinForTxOut protocolParams out
+                counterexample msg
+                    $ property
+                    $ not
+                    $ Write.isBelowMinimumCoinForTxOut protocolParams out
               where
                 msg =
                     unwords
@@ -1924,9 +1936,9 @@ prop_bootstrapWitnesses _era p n net accIxW addr0IxW =
             byronProtVer
             (BSL.fromStrict $ CA.unAddress addr) of
             Right byronAddr ->
-                aaVKDerivationPath $
-                    attrData $
-                        Chain.addrAttributes byronAddr
+                aaVKDerivationPath
+                    $ attrData
+                    $ Chain.addrAttributes byronAddr
             Left _ -> Nothing
 
 --------------------------------------------------------------------------------
@@ -2140,16 +2152,16 @@ balanceTxWithDummyChangeState
         (ErrBalanceTx era)
         (Tx era, DummyChangeState)
 balanceTxWithDummyChangeState utxoAssumptions utxo seed partialTx =
-    (`evalRand` stdGenFromSeed seed) $
-        runExceptT $
-            balanceTx
-                mockPParams
-                dummyTimeTranslation
-                utxoAssumptions
-                utxoIndex
-                dummyChangeAddrGen
-                (DummyChangeState 0)
-                partialTx
+    (`evalRand` stdGenFromSeed seed)
+        $ runExceptT
+        $ balanceTx
+            mockPParams
+            dummyTimeTranslation
+            utxoAssumptions
+            utxoIndex
+            dummyChangeAddrGen
+            (DummyChangeState 0)
+            partialTx
   where
     utxoIndex = constructUTxOIndex utxo
 
@@ -2291,12 +2303,12 @@ dummyChangeAddrGen =
         :: CA.Index 'CA.Soft 'CA.PaymentK
         -> Write.Address
     addressAtIx ix =
-        Convert.toLedgerAddress $
-            convert $
-                Shelley.delegationAddress
-                    Shelley.shelleyMainnet
-                    (Shelley.PaymentFromExtendedKey paymentK)
-                    (Shelley.DelegationFromExtendedKey stakeK)
+        Convert.toLedgerAddress
+            $ convert
+            $ Shelley.delegationAddress
+                Shelley.shelleyMainnet
+                (Shelley.PaymentFromExtendedKey paymentK)
+                (Shelley.DelegationFromExtendedKey stakeK)
       where
         paymentK =
             CA.toXPub
@@ -2345,16 +2357,16 @@ dummyByronChangeAddrGen =
 
     byronAddressAtIx :: Int -> Write.Address
     byronAddressAtIx i =
-        Convert.toLedgerAddress $
-            W.Address $
-                CA.unAddress $
-                    Byron.paymentAddress
-                        Byron.byronMainnet
-                        ( CA.toXPub
-                            <$> Byron.deriveAddressPrivateKey
-                                accK
-                                (CA.unsafeMkIndex $ fromIntegral i)
-                        )
+        Convert.toLedgerAddress
+            $ W.Address
+            $ CA.unAddress
+            $ Byron.paymentAddress
+                Byron.byronMainnet
+                ( CA.toXPub
+                    <$> Byron.deriveAddressPrivateKey
+                        accK
+                        (CA.unsafeMkIndex $ fromIntegral i)
+                )
 
 dummyTimeTranslation :: TimeTranslation
 dummyTimeTranslation =
@@ -2401,13 +2413,13 @@ pingPong_1 :: (TestRecentEra era) => PartialTx era
 pingPong_1 = PartialTx tx mempty mempty (StakeKeyDepositMap mempty) mempty
   where
     tx =
-        deserializeTx $
-            unsafeFromHex $
-                mconcat
-                    [ "84a30080018183581d714d72cf569a339a18a7d9302313983f56e0d96cd4"
-                    , "5bdcb1d6512dca6a1a001e84805820923918e403bf43c34b4ef6b48eb2ee04ba"
-                    , "bed17320d8d1b9ff9ad086e86f44ec0200a10481d87980f5f6"
-                    ]
+        deserializeTx
+            $ unsafeFromHex
+            $ mconcat
+                [ "84a30080018183581d714d72cf569a339a18a7d9302313983f56e0d96cd4"
+                , "5bdcb1d6512dca6a1a001e84805820923918e403bf43c34b4ef6b48eb2ee04ba"
+                , "bed17320d8d1b9ff9ad086e86f44ec0200a10481d87980f5f6"
+                ]
 
 pingPong_2 :: (TestRecentEra era) => PartialTx era
 pingPong_2 =
@@ -2425,22 +2437,22 @@ pingPong_2 =
                 [
                     ( Write.unsafeMkTxIn tid 0
                     , TxOutInRecentEra
-                        ( Write.unsafeAddressFromBytes $
-                            unsafeFromHex $
-                                mconcat
-                                    [ "714d72cf569a339a18a7d93023139"
-                                    , "83f56e0d96cd45bdcb1d6512dca6a"
-                                    ]
+                        ( Write.unsafeAddressFromBytes
+                            $ unsafeFromHex
+                            $ mconcat
+                                [ "714d72cf569a339a18a7d93023139"
+                                , "83f56e0d96cd45bdcb1d6512dca6a"
+                                ]
                         )
                         (ada 2)
-                        ( Write.DatumHash $
-                            fromJust $
-                                Write.datumHashFromBytes $
-                                    unsafeFromHex $
-                                        mconcat
-                                            [ "923918e403bf43c34b4ef6b48eb2ee04"
-                                            , "babed17320d8d1b9ff9ad086e86f44ec"
-                                            ]
+                        ( Write.DatumHash
+                            $ fromJust
+                            $ Write.datumHashFromBytes
+                            $ unsafeFromHex
+                            $ mconcat
+                                [ "923918e403bf43c34b4ef6b48eb2ee04"
+                                , "babed17320d8d1b9ff9ad086e86f44ec"
+                                ]
                         )
                         Nothing
                     )
@@ -2475,9 +2487,9 @@ signedTxTestData = do
 
 testParameter_coinsPerUTxOByte :: Ledger.CoinPerByte
 testParameter_coinsPerUTxOByte =
-    Ledger.CoinPerByte $
-        Ledger.compactCoinOrError $
-            Coin 4_310
+    Ledger.CoinPerByte
+        $ Ledger.compactCoinOrError
+        $ Coin 4_310
 
 testStdGenSeed :: StdGenSeed
 testStdGenSeed = StdGenSeed 0
@@ -2854,17 +2866,17 @@ genStakePoolKeyHash = genKeyHash'
 genByronAddr :: Gen Addr
 genByronAddr = do
     ix <- choose @Int (0, 1024)
-    pure $
-        Convert.toLedgerAddress $
-            W.Address $
-                CA.unAddress $
-                    Byron.paymentAddress
-                        Byron.byronMainnet
-                        ( CA.toXPub
-                            <$> Byron.deriveAddressPrivateKey
-                                accK
-                                (CA.unsafeMkIndex $ fromIntegral ix)
-                        )
+    pure
+        $ Convert.toLedgerAddress
+        $ W.Address
+        $ CA.unAddress
+        $ Byron.paymentAddress
+            Byron.byronMainnet
+            ( CA.toXPub
+                <$> Byron.deriveAddressPrivateKey
+                    accK
+                    (CA.unsafeMkIndex $ fromIntegral ix)
+            )
   where
     rootK = Byron.genMasterKeyFromMnemonic dummyMnemonic
     accK = Byron.deriveAccountPrivateKey rootK minBound
@@ -2972,15 +2984,15 @@ instance Buildable UTxOAssumptions where
 instance Buildable AnyChangeAddressGenWithState where
     build (AnyChangeAddressGenWithState (ChangeAddressGen g maxLengthAddr) s0) =
         blockListF
-            [ nameF "changeAddr0" $
-                build $
-                    show $
-                        fst $
-                            g s0
-            , nameF "max address length" $
-                build $
-                    BS.length $
-                        serialiseAddr maxLengthAddr
+            [ nameF "changeAddr0"
+                $ build
+                $ show
+                $ fst
+                $ g s0
+            , nameF "max address length"
+                $ build
+                $ BS.length
+                $ serialiseAddr maxLengthAddr
             ]
 
 -- CSV with the columns: wallet_balance,(fee,minfee | error)

--- a/test/spec/Cardano/Balance/Tx/SerializationSpec.hs
+++ b/test/spec/Cardano/Balance/Tx/SerializationSpec.hs
@@ -29,6 +29,7 @@ import Data.List
     ( isSuffixOf
     , sortOn
     )
+import Prelude
 import System.Directory
     ( listDirectory
     )
@@ -50,7 +51,6 @@ import Test.Utils.Paths
 import Text.Read
     ( readMaybe
     )
-import Prelude
 
 import qualified Data.ByteString as BS
 

--- a/test/spec/Cardano/Balance/Tx/TxSpec.hs
+++ b/test/spec/Cardano/Balance/Tx/TxSpec.hs
@@ -59,6 +59,7 @@ import Data.Word
     ( Word16
     , Word64
     )
+import Prelude
 import Test.Cardano.Ledger.Alonzo.Arbitrary
     (
     )
@@ -96,7 +97,6 @@ import Test.QuickCheck.Classes
 import Test.Utils.Laws
     ( testLawsMany
     )
-import Prelude
 
 import qualified Cardano.Crypto.Hash.Class as Crypto
 import qualified Cardano.Ledger.Coin as Ledger

--- a/test/spec/System/Random/StdGenSeed.hs
+++ b/test/spec/System/Random/StdGenSeed.hs
@@ -60,11 +60,11 @@ stdGenSeed :: (MonadRandom m) => m StdGenSeed
 stdGenSeed = do
     hi <- getRandom
     lo <- getRandom
-    pure $
-        StdGenSeed $
-            (.|.)
-                (fromIntegral @Word64 @Word127 hi `Bits.shiftL` 63)
-                (fromIntegral @Word64 @Word127 lo)
+    pure
+        $ StdGenSeed
+        $ (.|.)
+            (fromIntegral @Word64 @Word127 hi `Bits.shiftL` 63)
+            (fromIntegral @Word64 @Word127 lo)
 
 stdGenFromSeed :: StdGenSeed -> StdGen
 stdGenFromSeed =

--- a/test/spec/Test/Hspec/Extra.hs
+++ b/test/spec/Test/Hspec/Extra.hs
@@ -7,11 +7,11 @@ module Test.Hspec.Extra
     )
 where
 
+import Prelude
 import Test.Hspec
     ( Spec
     , hspec
     )
-import Prelude
 
 import qualified Test.Hspec as Hspec
 

--- a/test/spec/Test/QuickCheck/Extra.hs
+++ b/test/spec/Test/QuickCheck/Extra.hs
@@ -57,6 +57,7 @@ import Generics.SOP
 import Numeric.Natural
     ( Natural
     )
+import Prelude
 import Test.QuickCheck
     ( Gen
     , Property
@@ -67,7 +68,6 @@ import Test.QuickCheck
     , shrinkList
     , shrinkMapBy
     )
-import Prelude
 
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Strict as Map

--- a/test/spec/Test/Utils/Laws.hs
+++ b/test/spec/Test/Utils/Laws.hs
@@ -16,6 +16,7 @@ import Data.Typeable
     ( Typeable
     , typeRep
     )
+import Prelude
 import Test.Hspec
     ( Spec
     , describe
@@ -27,7 +28,6 @@ import Test.QuickCheck
 import Test.QuickCheck.Classes
     ( Laws (..)
     )
-import Prelude
 
 -- | Test multiple sets of laws for a type.
 testLawsMany

--- a/test/spec/Test/Utils/Pretty.hs
+++ b/test/spec/Test/Utils/Pretty.hs
@@ -7,11 +7,11 @@ module Test.Utils.Pretty
     )
 where
 
+import Prelude
 import Test.QuickCheck
     ( Property
     , (===)
     )
-import Prelude
 
 import qualified Text.Show.Pretty as P
 

--- a/test/spec/run-test-suite.hs
+++ b/test/spec/run-test-suite.hs
@@ -1,9 +1,9 @@
 module Main where
 
+import Prelude
 import Test.Hspec.Extra
     ( hspecMain
     )
-import Prelude
 
 import qualified Spec
 


### PR DESCRIPTION
Moves this repository's hardcoded pin set from `cardano-node` 11.0.1 to
11.1.0, including the mechanical source adaptations the majors force.

Closes #45

## Pin set (`cabal.project`)

- Both `index-state` stanzas bumped: hackage `2026-08-14T13:38:07Z`, CHaP
  `2026-08-17T11:39:16Z`.
- All 19 freeze-pinned constraints updated to the node-11.1.0 freeze values
  (`ouroboros-consensus 4.1.0.0`, `cardano-ledger-dijkstra 0.3.0.0`,
  `cardano-crypto-class 2.5.1.0`, `cardano-binary 1.9.1.0`, ...); the 11.0.1
  pins and the old index-state are gone.
- `-test` pins (`cardano-ledger-alonzo-test`, `cardano-ledger-shelley-ma-test`,
  not supplied by the node freeze): resolved from this repo's own CHaP solve
  at the new index-state — `==1.4.0.1` / `==1.4.0.2` — which happen to equal
  the pre-existing pins, so no edit was needed.
- `cardano-balance-tx.cabal` library bounds: freeze-lower / next-minor-upper
  for every pinned member.
- `flake.nix`/`flake.lock`: `indexState` bump, CHaP rev bump to match
  cardano-node 11.1.0's own `flake.lock`, and a haskellNix/hackage-snapshot
  rev bump (not a haskellNix generation bump) to resolve a stale-snapshot
  `cabal update` failure at the new index-state.
- `cardano-coin-selection` (source-repository-package): confirmed no ecosystem
  constraint forces a bump; left as-is.

## Mechanical adaptations

- `Redeemers.hs`: `Conway.ConwayRewarding`/`Dijkstra.DijkstraRewarding` →
  `...ConwayWithdrawing`/`...DijkstraWithdrawing`. The old names survive only
  as deprecated pattern synonyms of the same shape/CBOR tag in
  conway-1.23.0.0 / dijkstra-0.3.0.0.
- `Tx.hs`: `evaluateTransactionBalance` — `cardano-ledger-api` 1.14 dropped
  `evalBalanceTxBody`'s DRep-deposit-lookup callback; the DRep refund is now
  read by the ledger internally from the `Coin` carried in the `UnRegDRep`
  cert itself. Removed the now-dead callback, its where-binding, and the
  orphaned `ppDRepDepositL` import.
- `Eras.hs`: added `AlonzoEraUTxO era` to `RecentEraConstraints` —
  `alonzo-1.16`'s `evalTxExUnits` now requires it; the instance already
  exists for both `ConwayEra` and `DijkstraEra`.
- `BalanceSpec.hs`: extended the exhaustive `prop_dijkstraContextError`
  pattern match for the six `DijkstraContextError` constructors added in
  `cardano-ledger-dijkstra` 0.3.0.0.
- fourmolu 0.20.1.0 layout normalization of the four touched files (new
  index-state toolchain formats slightly differently).

## `cardano-ledger-dijkstra` 0.3.0.0 surface (reported per mandate)

Everything this repo uses from the Dijkstra surface was checked against the
extracted upstream source. Only one rename touches this repo (`DijkstraRewarding`
→ `DijkstraWithdrawing`, see above); `DijkstraNativeScript`, `UpgradeDijkstraPParams`,
the Dijkstra `TxCert` constructors, and `upgradeTimelock` are unchanged. This
finding was flagged to the epic owner separately as it bears on the wallet
epic's Dijkstra tracking, not just this PR.

One informational note: the Dijkstra balanced-tx binary golden
(`pingPong_2`) re-serializes with a different top-level CBOR array shape
under 0.3.0.0 (4-element → 3-element array). The golden test compares
*decoded* values, not raw bytes, and passes — this matches the repo's
documented Dijkstra canonicalization behavior. Byte-exact regeneration, if
ever wanted, is a separate decision.

## Verification

- `./gate.sh` (nix-native CI path — `nix build .#lib .#unit-tests` + `nix run
  .#unit-tests`, fourmolu, hlint): **GREEN**, reproduced independently three
  times (implementation, fresh audit, final ticket-owner re-run) —
  420 examples, 0 failures, 8 pre-existing documented pendings.
- Independently audited by a fresh alternate-family reviewer against the
  frozen mandate; zero blocking findings.

### Gate-topology note (Q1, already resolved)

`cabal build all --enable-tests` inside `nix develop` is unsatisfiable on
this repo's current haskell.nix generation (`Cabal-7107` — a structural
sub-libraries/shell-DB limitation, pre-existing at the 11.0.1 pin set too,
not introduced by this change). Acceptance for this slice therefore uses the
repository's own `nix build`/`nix run` CI path, which does exercise the full
dependency stack and the full unit-test suite.
